### PR TITLE
Set conditions on the Microsoft.CSharp, Microsoft.VisualBasic, and Microsoft.Cpp modules to not declare properties for projects that aren't applicable

### DIFF
--- a/src/CBT.Microsoft.CSharp.targets/CBT.Microsoft.CSharp.targets.nuspec
+++ b/src/CBT.Microsoft.CSharp.targets/CBT.Microsoft.CSharp.targets.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>CBT.Microsoft.CSharp.targets</id>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <authors>CBT Developers</authors>
     <owners>CBT Developers</owners>
     <licenseUrl>https://raw.githubusercontent.com/CommonBuildToolset/CBT.Modules/master/LICENSE</licenseUrl>

--- a/src/CBT.Microsoft.CSharp.targets/Module/Build.props
+++ b/src/CBT.Microsoft.CSharp.targets/Module/Build.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(MSBuildProjectExtension)' == '.csproj' Or '$(ForceImportCBTMicrosoftCSharpTargets)' == 'true' ">
     <SavedCustomBeforeMicrosoftCSharpTargets>$(CustomBeforeMicrosoftCSharpTargets)</SavedCustomBeforeMicrosoftCSharpTargets>
     <SavedCustomAfterMicrosoftCSharpTargets>$(CustomAfterMicrosoftCSharpTargets)</SavedCustomAfterMicrosoftCSharpTargets>
 

--- a/src/CBT.Microsoft.Cpp.targets/CBT.Microsoft.Cpp.targets.nuspec
+++ b/src/CBT.Microsoft.Cpp.targets/CBT.Microsoft.Cpp.targets.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>CBT.Microsoft.Cpp.targets</id>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <authors>CBT Developers</authors>
     <owners>CBT Developers</owners>
     <licenseUrl>https://raw.githubusercontent.com/CommonBuildToolset/CBT.Modules/master/LICENSE</licenseUrl>

--- a/src/CBT.Microsoft.Cpp.targets/Module/Build.props
+++ b/src/CBT.Microsoft.Cpp.targets/Module/Build.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(MSBuildProjectExtension)' == '.vcxproj' Or '$(ForceImportCBTMicrosoftCppTargets)' == 'true' ">
     <SavedForceImportBeforeCppTargets>$(ForceImportBeforeCppTargets)</SavedForceImportBeforeCppTargets>
     <SavedForceImportAfterCppTargets>$(ForceImportAfterCppTargets)</SavedForceImportAfterCppTargets>
 

--- a/src/CBT.Microsoft.VisualBasic.targets/CBT.Microsoft.VisualBasic.targets.nuspec
+++ b/src/CBT.Microsoft.VisualBasic.targets/CBT.Microsoft.VisualBasic.targets.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>CBT.Microsoft.VisualBasic.targets</id>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <authors>CBT Developers</authors>
     <owners>CBT Developers</owners>
     <licenseUrl>https://raw.githubusercontent.com/CommonBuildToolset/CBT.Modules/master/LICENSE</licenseUrl>

--- a/src/CBT.Microsoft.VisualBasic.targets/Module/Build.props
+++ b/src/CBT.Microsoft.VisualBasic.targets/Module/Build.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(MSBuildProjectExtension)' == '.vbproj' Or '$(ForceImportCBTMicrosoftVisualBasicTargets)' == 'true' ">
     <SavedCustomBeforeMicrosoftVisualBasicTargets>$(CustomBeforeMicrosoftVisualBasicTargets)</SavedCustomBeforeMicrosoftVisualBasicTargets>
     <SavedCustomAfterMicrosoftVisualBasicTargets>$(CustomAfterMicrosoftVisualBasicTargets)</SavedCustomAfterMicrosoftVisualBasicTargets>
 


### PR DESCRIPTION
Set conditions on the Microsoft.CSharp, Microsoft.VisualBasic, and Microsoft.Cpp modules to not declare properties for projects that aren't applicable

- Only declare the properties if the project is the related type
- Allow for importing even if the project file extension doesn't match
- Update NuSpec version

