### PR TITLE
Update CBT.NuGet module to support multiple versions of MSBuild

### DIFF
--- a/src/CBT.NuGet/CBT.NuGet.csproj
+++ b/src/CBT.NuGet/CBT.NuGet.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>CBT.NuGet</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-	<OutputPath>bin\Debug\$(MSBuildToolsVersion)\</OutputPath>
+    <OutputPath>bin\Debug\$(MSBuildToolsVersion)\</OutputPath>
     <MsBuildUtilitiesAssemblyName>Microsoft.Build.Utilities.v$(MSBuildToolsVersion)</MsBuildUtilitiesAssemblyName>
     <MsBuildUtilitiesAssemblyName Condition="'$(MSBuildToolsVersion)' == '14.0'">Microsoft.Build.Utilities.Core</MsBuildUtilitiesAssemblyName>
   </PropertyGroup>

--- a/src/CBT.NuGet/CBT.NuGet.csproj
+++ b/src/CBT.NuGet/CBT.NuGet.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>CBT.NuGet</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+	<OutputPath>bin\Debug\$(MSBuildToolsVersion)\</OutputPath>
     <MsBuildUtilitiesAssemblyName>Microsoft.Build.Utilities.v$(MSBuildToolsVersion)</MsBuildUtilitiesAssemblyName>
     <MsBuildUtilitiesAssemblyName Condition="'$(MSBuildToolsVersion)' == '14.0'">Microsoft.Build.Utilities.Core</MsBuildUtilitiesAssemblyName>
   </PropertyGroup>
@@ -18,7 +19,6 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -26,7 +26,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/CBT.NuGet/CBT.NuGet.nuspec
+++ b/src/CBT.NuGet/CBT.NuGet.nuspec
@@ -19,7 +19,7 @@
   </metadata>
   <files>
     <file src="bin\Debug\12.0\CBT.NuGet.dll" target="CBT\Module\v12.0" />
-	<file src="bin\Debug\14.0\CBT.NuGet.dll" target="CBT\Module\v14.0" />
+    <file src="bin\Debug\14.0\CBT.NuGet.dll" target="CBT\Module\v14.0" />
     <file src="CBT.NuGet.targets" target="CBT\Module" />
     <file src="Build.props" target="CBT\Module" />
     <file src="After.Traversal.targets" target="CBT\Module" />

--- a/src/CBT.NuGet/CBT.NuGet.nuspec
+++ b/src/CBT.NuGet/CBT.NuGet.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>CBT.NuGet</id>
-    <version>1.0.0-beta6</version>
+    <version>1.0.0-beta7</version>
     <title>CBT NuGet Module</title>
     <authors>CBT Developers</authors>
     <owners>CBT Developers</owners>
@@ -18,7 +18,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\Debug\CBT.NuGet.dll" target="CBT\Module" />
+    <file src="bin\Debug\12.0\CBT.NuGet.dll" target="CBT\Module\v12.0" />
+	<file src="bin\Debug\14.0\CBT.NuGet.dll" target="CBT\Module\v14.0" />
     <file src="CBT.NuGet.targets" target="CBT\Module" />
     <file src="Build.props" target="CBT\Module" />
     <file src="After.Traversal.targets" target="CBT\Module" />

--- a/src/CBT.NuGet/CBT.NuGet.nuspec
+++ b/src/CBT.NuGet/CBT.NuGet.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>CBT.NuGet</id>
-    <version>1.0.0-beta7</version>
+    <version>1.0.0-beta8</version>
     <title>CBT NuGet Module</title>
     <authors>CBT Developers</authors>
     <owners>CBT Developers</owners>

--- a/src/CBT.NuGet/build.props
+++ b/src/CBT.NuGet/build.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <CBTNuGetTasksAssemblyPath Condition=" '$(CBTNuGetTasksAssemblyPath)' == '' ">$(MSBuildThisFileDirectory)CBT.NuGet.dll</CBTNuGetTasksAssemblyPath>
+    <CBTNuGetTasksAssemblyPath Condition=" '$(CBTNuGetTasksAssemblyPath)' == '' ">$(MSBuildThisFileDirectory)v$(MSBuildToolsVersion)\CBT.NuGet.dll</CBTNuGetTasksAssemblyPath>
     <CBTNuGetAllProjects>$(CBTNuGetAllProjects);$(MSBuildThisFileFullPath);$(MSBuildThisFileDirectory)CBT.NuGet.targets;$(CBTNuGetTasksAssemblyPath)</CBTNuGetAllProjects>
     <CBTEnablePackageRestore Condition=" '$(CBTEnablePackageRestore)' == '' And '$(BuildingInsideVisualStudio)' != 'true' ">true</CBTEnablePackageRestore>
     <CBTNuGetPath Condition=" '$(CBTNuGetPath)' == '' And '$(CBTModuleRestoreCommand)' != '' And $([System.IO.Path]::GetFileName($(CBTModuleRestoreCommand))) == 'NuGet.exe' And Exists($(CBTModuleRestoreCommand)) ">$([System.IO.Path]::GetDirectoryName($(CBTModuleRestoreCommand)))</CBTNuGetPath>


### PR DESCRIPTION
Update CBT.NuGet module to support multiple versions of MSBuild (#10)

Include the assembly compiled against 12.0 and 14.0