### PR TITLE
DotNetFx reference assemblies module

### DIFF
--- a/src/CBT.DotNetFx/CBT.DotNetFx.nuspec
+++ b/src/CBT.DotNetFx/CBT.DotNetFx.nuspec
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>CBT.DotNetFx</id>
+    <version>$version$</version>
+    <authors>CBT</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Contains the reference assemblies for the .NET Framework v4.0</description>
+  </metadata>
+
+  <files>
+    <file src="build-$DisplayName$.props" target="CBT\Module\build.props" />
+	<file src="$Root$\**\*" target="CBT\Module\$DisplayName$\" />
+  </files>
+</package>

--- a/src/CBT.DotNetFx/CBT.DotNetFx.nuspec
+++ b/src/CBT.DotNetFx/CBT.DotNetFx.nuspec
@@ -5,11 +5,11 @@
     <version>$version$</version>
     <authors>CBT</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Contains the reference assemblies for the .NET Framework v4.0</description>
+    <description>Contains the reference assemblies for the .NET Framework $DisplayVersion$</description>
   </metadata>
 
   <files>
     <file src="build-$DisplayName$.props" target="CBT\Module\build.props" />
-	<file src="$Root$\**\*" target="CBT\Module\$DisplayName$\" />
+    <file src="$Root$\**\*" target="CBT\Module\$DisplayName$\" />
   </files>
 </package>

--- a/src/CBT.DotNetFx/build-net40.props
+++ b/src/CBT.DotNetFx/build-net40.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <FrameworkPathOverride Condition=" '$(FrameworkPathOverride)' == '' And '$(TargetFrameworkVersion)' == 'v4.0' ">$(MSBuildThisFileDirectory)net40</FrameworkPathOverride>
+  </PropertyGroup>
+
+</Project>

--- a/src/CBT.DotNetFx/build-net45.props
+++ b/src/CBT.DotNetFx/build-net45.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <FrameworkPathOverride Condition=" '$(FrameworkPathOverride)' == '' And '$(TargetFrameworkVersion)' == 'v4.5' ">$(MSBuildThisFileDirectory)net45</FrameworkPathOverride>
+  </PropertyGroup>
+
+</Project>

--- a/src/CBT.DotNetFx/build-net451.props
+++ b/src/CBT.DotNetFx/build-net451.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <FrameworkPathOverride Condition=" '$(FrameworkPathOverride)' == '' And '$(TargetFrameworkVersion)' == 'v4.5.1' ">$(MSBuildThisFileDirectory)net451</FrameworkPathOverride>
+  </PropertyGroup>
+
+</Project>

--- a/src/CBT.DotNetFx/build-net452.props
+++ b/src/CBT.DotNetFx/build-net452.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <FrameworkPathOverride Condition=" '$(FrameworkPathOverride)' == '' And '$(TargetFrameworkVersion)' == 'v4.5.2' ">$(MSBuildThisFileDirectory)net452</FrameworkPathOverride>
+  </PropertyGroup>
+
+</Project>

--- a/src/CBT.DotNetFx/build-net46.props
+++ b/src/CBT.DotNetFx/build-net46.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <FrameworkPathOverride Condition=" '$(FrameworkPathOverride)' == '' And '$(TargetFrameworkVersion)' == 'v4.6' ">$(MSBuildThisFileDirectory)net46</FrameworkPathOverride>
+  </PropertyGroup>
+
+</Project>

--- a/src/CBT.DotNetFx/build-net461.props
+++ b/src/CBT.DotNetFx/build-net461.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <FrameworkPathOverride Condition=" '$(FrameworkPathOverride)' == '' And '$(TargetFrameworkVersion)' == 'v4.6.1' ">$(MSBuildThisFileDirectory)net461</FrameworkPathOverride>
+  </PropertyGroup>
+
+</Project>

--- a/src/CBT.DotNetFx/packall.cmd
+++ b/src/CBT.DotNetFx/packall.cmd
@@ -1,0 +1,30 @@
+@ECHO OFF
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+SET "NETFXTAG=-beta1"
+IF "%ProgramFiles(x86)%" NEQ "" (
+	SET "REFERENCEASSEMBLYROOT=%ProgramFiles(x86)%\Reference Assemblies"
+) ELSE (
+	SET "REFERENCEASSEMBLYROOT=%ProgramFiles%\Reference Assemblies"
+)
+
+FOR %%A IN (4.0.0,4.5.0,4.5.1,4.5.2,4.6.0,4.6.1) DO (
+	SET DisplayName=net%%A
+	SET DisplayName=!DisplayName:.=!
+	IF "!DisplayName:~5,1!" EQU "0" (
+		SET DisplayName=!DisplayName:~0,5!
+	)
+	SET DisplayVersion=v%%A
+	IF "!DisplayVersion:~5,1!" EQU "0" (
+		SET DisplayVersion=!DisplayVersion:~0,4!
+	)
+	
+	SET "ROOT=%REFERENCEASSEMBLYROOT%\Microsoft\Framework\.NETFramework\!DisplayVersion!"
+
+	IF NOT EXIST "!ROOT!" (
+		ECHO .NET Framework reference assemblies were not found at !ROOT!.  Ensure the .NET Framework SDK is installed for this version and try again.
+	) ELSE (
+		ECHO Version %%A%NETFXTAG% - !DisplayName! - !DisplayVersion! - "!ROOT!"
+		NuGet PACK "%~dp0CBT.DotNetFx.nuspec" -Properties "Version=%%A%NETFXTAG%;DisplayName=!DisplayName!;Root=!ROOT!" -NoPackageAnalysis -NoDefaultExcludes -O "%~dp0.."
+	)
+)

--- a/src/CBT.DotNetFx/packall.cmd
+++ b/src/CBT.DotNetFx/packall.cmd
@@ -1,7 +1,7 @@
 @ECHO OFF
 SETLOCAL ENABLEDELAYEDEXPANSION
 
-SET "NETFXTAG=-beta1"
+SET "NETFXTAG=-beta01"
 IF "%ProgramFiles(x86)%" NEQ "" (
 	SET "REFERENCEASSEMBLYROOT=%ProgramFiles(x86)%\Reference Assemblies"
 ) ELSE (
@@ -25,6 +25,6 @@ FOR %%A IN (4.0.0,4.5.0,4.5.1,4.5.2,4.6.0,4.6.1) DO (
 		ECHO .NET Framework reference assemblies were not found at !ROOT!.  Ensure the .NET Framework SDK is installed for this version and try again.
 	) ELSE (
 		ECHO Version %%A%NETFXTAG% - !DisplayName! - !DisplayVersion! - "!ROOT!"
-		NuGet PACK "%~dp0CBT.DotNetFx.nuspec" -Properties "Version=%%A%NETFXTAG%;DisplayName=!DisplayName!;Root=!ROOT!" -NoPackageAnalysis -NoDefaultExcludes -O "%~dp0.."
+		NuGet PACK "%~dp0CBT.DotNetFx.nuspec" -Properties "Version=%%A%NETFXTAG%;DisplayName=!DisplayName!;DisplayVersion=!DisplayVersion!;Root=!ROOT!" -NoPackageAnalysis -NoDefaultExcludes -O "%~dp0.."
 	)
 )

--- a/src/packall.cmd
+++ b/src/packall.cmd
@@ -1,4 +1,4 @@
 @ECHO OFF
-FOR /F "usebackq" %%A IN (`dir %~dp0*.nuspec /s /b`) DO (
-	"NuGet.exe" pack "%%A" -OutputDirectory %~dp0
+FOR /F "usebackq" %%A IN (`dir %~dp0*.nuspec /s /b ^| findstr /v /i "CBT.DotNetFx"`) DO (
+	ECHO "NuGet.exe" pack "%%A" -OutputDirectory %~dp0
 )

--- a/src/packall.cmd
+++ b/src/packall.cmd
@@ -1,4 +1,4 @@
 @ECHO OFF
 FOR /F "usebackq" %%A IN (`dir %~dp0*.nuspec /s /b ^| findstr /v /i "CBT.DotNetFx"`) DO (
-	ECHO "NuGet.exe" pack "%%A" -OutputDirectory %~dp0
+	"NuGet.exe" pack "%%A" -OutputDirectory %~dp0
 )


### PR DESCRIPTION
Contains the .NET reference assemblies so that code bases can build even when the reference assembly for the target framework aren't installed.