### PR TITLE
Support for importing standard NuGet build packages as modules

### DIFF
--- a/src/CBT.NuGet/After.Microsoft.Common.targets
+++ b/src/CBT.NuGet/After.Microsoft.Common.targets
@@ -7,5 +7,7 @@
   </PropertyGroup>
 
   <Import Project="$(NuGetTargets)" Condition=" '$(NuGetTargets)' != '' And !Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.targets\ImportAfter\Microsoft.NuGet.ImportAfter.targets') " />
+
+  <Import Project="$(CBTBuildPackageTargetsFile)" Condition=" '$(CBTEnableImportBuildPackages)' != 'false' "/>
   
 </Project>

--- a/src/CBT.NuGet/CBT.NuGet.csproj
+++ b/src/CBT.NuGet/CBT.NuGet.csproj
@@ -39,9 +39,7 @@
   <ItemGroup>
     <None Include="After.Microsoft.Common.targets" />
     <None Include="After.Traversal.targets" />
-    <None Include="build.props">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="build.props" />
     <None Include="CBT.NuGet.nuspec" />
     <None Include="CBT.NuGet.targets" />
     <None Include="Microsoft.NuGet\Microsoft.NuGet.Build.Tasks.dll" />

--- a/src/CBT.NuGet/CBT.NuGet.csproj
+++ b/src/CBT.NuGet/CBT.NuGet.csproj
@@ -25,6 +25,7 @@
     <Compile Include="Internal\ExtensionMethods.cs" />
     <Compile Include="Internal\NuGetPropertyGenerator.cs" />
     <Compile Include="Internal\PackageInfo.cs" />
+    <Compile Include="Tasks\ImportBuildPackages.cs" />
     <Compile Include="Tasks\NuGetAdd.cs" />
     <Compile Include="Tasks\NuGetConfig.cs" />
     <Compile Include="Tasks\NuGetDelete.cs" />
@@ -38,7 +39,9 @@
   <ItemGroup>
     <None Include="After.Microsoft.Common.targets" />
     <None Include="After.Traversal.targets" />
-    <None Include="build.props" />
+    <None Include="build.props">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="CBT.NuGet.nuspec" />
     <None Include="CBT.NuGet.targets" />
     <None Include="Microsoft.NuGet\Microsoft.NuGet.Build.Tasks.dll" />

--- a/src/CBT.NuGet/CBT.NuGet.nuspec
+++ b/src/CBT.NuGet/CBT.NuGet.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>CBT.NuGet</id>
-    <version>1.0.3-beta</version>
+    <version>1.0.4-beta</version>
     <title>CBT NuGet Module</title>
     <authors>CBT Developers</authors>
     <owners>CBT Developers</owners>

--- a/src/CBT.NuGet/Tasks/ImportBuildPackages.cs
+++ b/src/CBT.NuGet/Tasks/ImportBuildPackages.cs
@@ -1,0 +1,200 @@
+﻿using CBT.NuGet.Internal;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace CBT.NuGet.Tasks
+{
+    /// <summary>
+    /// A class for creating imports to NuGet build packages as if they are modules.
+    /// </summary>
+    public sealed class ImportBuildPackages : Task
+    {
+        /// <summary>
+        /// The path to the modules packages.config.
+        /// </summary>
+        public string ModulePackagesConfig { get; set; }
+
+        /// <summary>
+        /// The paths to modules.
+        /// </summary>
+        public string[] ModulePaths { get; set; }
+
+        /// <summary>
+        /// The path to the .props file to create.
+        /// </summary>
+        public string PropsFile { get; set; }
+
+        /// <summary>
+        /// The path to the .targets file to create.
+        /// </summary>
+        public string TargetsFile { get; set; }
+
+        public override bool Execute()
+        {
+            if (File.Exists(PropsFile) && File.Exists(TargetsFile))
+            {
+                return true;
+            }
+
+            string semaphoreName = PropsFile.ToUpper().GetHashCode().ToString("X");
+
+            bool releaseSemaphore;
+
+            using (Semaphore semaphore = new Semaphore(0, 1, semaphoreName, out releaseSemaphore))
+            {
+                try
+                {
+                    if (!releaseSemaphore)
+                    {
+                        releaseSemaphore = semaphore.WaitOne(TimeSpan.FromMinutes(5));
+
+                        return releaseSemaphore;
+                    }
+
+                    return GenerateBuildPackageImportFile();
+                }
+                finally
+                {
+                    if (releaseSemaphore)
+                    {
+                        semaphore.Release();
+                    }
+                }
+            }
+        }
+
+        public bool Execute(string modulePackagesConfig, string propsFile, string targetsFile, string[] inputs, string[] modulePaths)
+        {
+            if (File.Exists(PropsFile) && File.Exists(TargetsFile) && IsFileUpToDate(propsFile, inputs) && IsFileUpToDate(targetsFile, inputs))
+            {
+                return true;
+            }
+
+            BuildEngine = new CBTBuildEngine();
+
+            ModulePackagesConfig = modulePackagesConfig;
+            PropsFile = propsFile;
+            TargetsFile = targetsFile;
+            ModulePaths = modulePaths;
+
+            return Execute();
+        }
+
+        /// <summary>
+        /// Determines if a file is up-to-date in relation to the specified paths.
+        /// </summary>
+        /// <param name="input">The file to check if it is out-of-date.</param>
+        /// <param name="outputs">The list of files to check against.</param>
+        /// <returns><code>true</code> if the file does not exist or it is older than any of the other files.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="input"/> is <code>null</code>.</exception>
+        private static bool IsFileUpToDate(string input, params string[] outputs)
+        {
+            if (String.IsNullOrWhiteSpace(input))
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            if (!File.Exists(input) || outputs == null || outputs.Length == 0)
+            {
+                return false;
+            }
+
+            long lastWriteTime = File.GetLastWriteTimeUtc(input).Ticks;
+
+            return outputs.All(output => File.Exists(output) && File.GetLastWriteTimeUtc(output).Ticks <= lastWriteTime);
+        }
+
+        private bool GenerateBuildPackageImportFile()
+        {
+            Log.LogMessage("Creating NuGet build package imports");
+
+            ProjectRootElement propsProject = ProjectRootElement.Create(PropsFile);
+            ProjectRootElement targetsProject = ProjectRootElement.Create(TargetsFile);
+
+            ProjectPropertyGroupElement propertyGroup = propsProject.AddPropertyGroup();
+
+            foreach (BuildPackageInfo buildPackageInfo in ModulePaths.Select(BuildPackageInfo.FromModulePath).Where(i => i != null))
+            {
+                ProjectPropertyElement enableProperty = propertyGroup.AddProperty(buildPackageInfo.EnablePropertyName, "false");
+                enableProperty.Condition = $" '$({buildPackageInfo.EnablePropertyName})' == '' ";
+
+                ProjectPropertyElement runProperty = propertyGroup.AddProperty(buildPackageInfo.RunPropertyName, "true");
+                runProperty.Condition = $" '$({buildPackageInfo.RunPropertyName})' == '' ";
+
+                if (File.Exists(buildPackageInfo.PropsPath))
+                {
+                    ProjectImportElement import = propsProject.AddImport(buildPackageInfo.PropsPath);
+
+                    import.Condition = $" '$({buildPackageInfo.EnablePropertyName})' == 'true' And '$({buildPackageInfo.RunPropertyName})' == 'true' ";
+                }
+
+                if (File.Exists(buildPackageInfo.TargetsPath))
+                {
+                    ProjectImportElement import = targetsProject.AddImport(buildPackageInfo.TargetsPath);
+
+                    import.Condition = $" '$({buildPackageInfo.EnablePropertyName})' == 'true' And '$({buildPackageInfo.RunPropertyName})' == 'true' ";
+                }
+
+                Log.LogMessage(MessageImportance.High, "[{0}] {1} {2}", Thread.CurrentThread.ManagedThreadId, buildPackageInfo.Id, buildPackageInfo.RunPropertyName);
+            }
+
+            propsProject.Save();
+            targetsProject.Save();
+
+            return true;
+        }
+
+        private class BuildPackageInfo
+        {
+            private BuildPackageInfo()
+            {
+            }
+
+            public string EnablePropertyName { get; private set; }
+
+            public string Id { get; private set; }
+
+            public string PropsPath { get; private set; }
+
+            public string RunPropertyName { get; private set; }
+
+            public string TargetsPath { get; private set; }
+
+            public static BuildPackageInfo FromModulePath(string modulePath)
+            {
+                string[] parts = modulePath.Split(new[] {'='}, 2, StringSplitOptions.RemoveEmptyEntries);
+
+                if (parts.Length != 2 || String.IsNullOrWhiteSpace(parts[0]) || String.IsNullOrWhiteSpace(parts[1]))
+                {
+                    return null;
+                }
+                string id = parts[0];
+                string path = parts[1];
+
+                string propsPath = Path.Combine(path, "build", $"{id}.props");
+                string targetsPath = Path.Combine(path, "build", $"{id}.targets");
+
+                if (!File.Exists(propsPath) && !File.Exists(targetsPath))
+                {
+                    return null;
+                }
+
+                BuildPackageInfo buildPackageInfo = new BuildPackageInfo
+                {
+                    Id = parts[0],
+                    PropsPath = propsPath,
+                    TargetsPath = targetsPath,
+                    EnablePropertyName = $"Enable{id.Replace(".", "_")}",
+                    RunPropertyName = $"Run{id.Replace(".", "_")}",
+                };
+
+                return buildPackageInfo;
+            }
+        }
+    }
+}

--- a/src/CBT.NuGet/build.props
+++ b/src/CBT.NuGet/build.props
@@ -51,8 +51,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(CBTEnableImportBuildPackages)' != 'false' ">
-    <CBTBuildPackagePropsFile Condition=" '$(CBTBuildPackagePropsFile)' == '' ">$(CBTModulePath)\BuildPackages.props</CBTBuildPackagePropsFile>
-    <CBTBuildPackageTargetsFile Condition=" '$(CBTBuildPackageTargetsFile)' == '' ">$(CBTModulePath)\BuildPackages.targets</CBTBuildPackageTargetsFile>
+    <CBTBuildPackagePropsFile Condition=" '$(CBTBuildPackagePropsFile)' == '' ">$(CBTModulePath)\NuGetBuildPackages.props</CBTBuildPackagePropsFile>
+    <CBTBuildPackageTargetsFile Condition=" '$(CBTBuildPackageTargetsFile)' == '' ">$(CBTModulePath)\NuGetBuildPackages.targets</CBTBuildPackageTargetsFile>
     <CBTBuildPackageImportInputs Condition=" '$(CBTBuildPackageImportInputs)' == '' ">$(MSBuildThisFileFullPath);$(CBTNuGetTasksAssemblyPath);$(CBTModulePackageConfigPath)</CBTBuildPackageImportInputs>
     
     <CBTGlobalBuildPackagesCreated>$(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType('System.AppDomain').GetProperty('CurrentDomain').GetValue(null).CreateInstanceFromAndUnwrap('$(CBTNuGetTasksAssemblyPath)', 'CBT.NuGet.Tasks.ImportBuildPackages').Execute('$(CBTModulePackageConfigPath)', '$(CBTBuildPackagePropsFile)', '$(CBTBuildPackageTargetsFile)', $(CBTBuildPackageImportInputs.Split(';')), $(CBTAllModulePaths.Split(';'))))</CBTGlobalBuildPackagesCreated>

--- a/src/CBT.NuGet/build.props
+++ b/src/CBT.NuGet/build.props
@@ -6,6 +6,7 @@
     <CBTNuGetAllProjects>$(CBTNuGetAllProjects);$(MSBuildThisFileFullPath);$(MSBuildThisFileDirectory)CBT.NuGet.targets;$(MSBuildThisFileDirectory)After.Microsoft.Common.targets;$(CBTNuGetTasksAssemblyPath)</CBTNuGetAllProjects>
     <CBTEnablePackageRestore Condition=" '$(CBTEnablePackageRestore)' == '' ">true</CBTEnablePackageRestore>
     <CBTNuGetPath Condition=" '$(CBTNuGetPath)' == '' And '$(CBTModuleRestoreCommand)' != '' And $([System.IO.Path]::GetFileName($(CBTModuleRestoreCommand))) == 'NuGet.exe' And Exists($(CBTModuleRestoreCommand)) ">$([System.IO.Path]::GetDirectoryName($(CBTModuleRestoreCommand)))</CBTNuGetPath>
+    <CBTEnableImportBuildPackages Condition=" '$(CBTEnableImportBuildPackages)' == '' ">true</CBTEnableImportBuildPackages>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(CBTEnablePackageRestore)' == 'true' And '$(CBTNuGetRestoreFile)' == '' And Exists('$(MSBuildProjectDirectory)\project.json') ">
@@ -49,10 +50,20 @@
     <CBTNuGetPackagePropertiesCreated>$(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType('System.AppDomain').GetProperty('CurrentDomain').GetValue(null).CreateInstanceFromAndUnwrap($(CBTNuGetTasksAssemblyPath), 'CBT.NuGet.Tasks.NuGetRestore').GenerateNuGetProperties($(CBTNuGetRestoreFile), $(CBTNuGetAllProjects.Split(';')), $(CBTNuGetPackagePropertyFile), $(CBTNuGetPackagePropertyNamePrefix), $(CBTNuGetPackagePropertyValuePrefix)))</CBTNuGetPackagePropertiesCreated>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(CBTEnableImportBuildPackages)' != 'false' ">
+    <CBTBuildPackagePropsFile Condition=" '$(CBTBuildPackagePropsFile)' == '' ">$(CBTModulePath)\BuildPackages.props</CBTBuildPackagePropsFile>
+    <CBTBuildPackageTargetsFile Condition=" '$(CBTBuildPackageTargetsFile)' == '' ">$(CBTModulePath)\BuildPackages.targets</CBTBuildPackageTargetsFile>
+    <CBTBuildPackageImportInputs Condition=" '$(CBTBuildPackageImportInputs)' == '' ">$(MSBuildThisFileFullPath);$(CBTNuGetTasksAssemblyPath);$(CBTModulePackageConfigPath)</CBTBuildPackageImportInputs>
+    
+    <CBTGlobalBuildPackagesCreated>$(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType('System.AppDomain').GetProperty('CurrentDomain').GetValue(null).CreateInstanceFromAndUnwrap('$(CBTNuGetTasksAssemblyPath)', 'CBT.NuGet.Tasks.ImportBuildPackages').Execute('$(CBTModulePackageConfigPath)', '$(CBTBuildPackagePropsFile)', '$(CBTBuildPackageTargetsFile)', $(CBTBuildPackageImportInputs.Split(';')), $(CBTAllModulePaths.Split(';'))))</CBTGlobalBuildPackagesCreated>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)CBT.NuGet.targets" />
 
   <Import Project="$(CBTNuGetPackagePropertyFile)" Condition=" '$(CBTNuGetPackagePropertiesCreated)' == 'true' And Exists('$(CBTNuGetPackagePropertyFile)') "/>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NuGet\Microsoft.NuGet.props" Condition=" '$(IncludeNuGetImports)' != 'false' "/>
+
+  <Import Project="$(CBTBuildPackagePropsFile)" Condition=" '$(CBTEnableImportBuildPackages)' != 'false' "/>
 
 </Project>


### PR DESCRIPTION
I added this logic to the NuGet module because all of these are NuGet packages anyway.

It looks for the corresponding PackageId.props and PackageId.targets in the package and generates the appropriate Enable* and Run* properties as well as the imports.