### PR TITLE
Create UnifiedOutput module

### DIFF
--- a/src/CBT.Modules.sln
+++ b/src/CBT.Modules.sln
@@ -42,6 +42,8 @@ Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "CBT.After.Any.Targets", "CB
 EndProject
 Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "CBT.NuGet.GlobalRestore", "CBT.NuGet.GlobalRestore\CBT.NuGet.GlobalRestore.nuproj", "{525E50EB-C6D9-497D-BC54-C625AB62B7D0}"
 EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "CBT.UnifiedOutputDir", "CBT.UnifiedOutputDir\CBT.UnifiedOutputDir.nuproj", "{9CF55E9D-97E1-4FC4-ABE7-2E5701A8485F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -92,6 +94,10 @@ Global
 		{525E50EB-C6D9-497D-BC54-C625AB62B7D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{525E50EB-C6D9-497D-BC54-C625AB62B7D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{525E50EB-C6D9-497D-BC54-C625AB62B7D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9CF55E9D-97E1-4FC4-ABE7-2E5701A8485F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9CF55E9D-97E1-4FC4-ABE7-2E5701A8485F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9CF55E9D-97E1-4FC4-ABE7-2E5701A8485F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9CF55E9D-97E1-4FC4-ABE7-2E5701A8485F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/CBT.UnifiedOutputDir/CBT.UnifiedOutputDir.nuproj
+++ b/src/CBT.UnifiedOutputDir/CBT.UnifiedOutputDir.nuproj
@@ -3,19 +3,15 @@
   <PropertyGroup Label="Configuration">
     <Description>Provides NuGet related build tasks for CBT.</Description>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <ProjectGuid>20b4c0c1-5c4e-4dd0-9994-d89e78c3b161</ProjectGuid>
+    <ProjectGuid>9cf55e9d-97e1-4fc4-abe7-2e5701a8485f</ProjectGuid>
     <Tags>CBT Module NuGet</Tags>
     <Title>CBT NuGet Module</Title>
   </PropertyGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.props))\build.props" />
-
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
-
   <ItemGroup>
     <Content Include="CBT\Module\Build.props" />
     <None Include="version.json" />
   </ItemGroup>
-
   <Import Project="$(NuProjPath)\NuProj.targets" Condition="Exists('$(NuProjPath)\NuProj.targets')" />
 </Project>

--- a/src/CBT.UnifiedOutputDir/CBT.UnifiedOutputDir.nuproj
+++ b/src/CBT.UnifiedOutputDir/CBT.UnifiedOutputDir.nuproj
@@ -11,6 +11,8 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <ItemGroup>
     <Content Include="CBT\Module\Build.props" />
+    <Content Include="CBT\Module\CBT.UnifiedOutputDir.props" />
+    <Content Include="CBT\Module\module.config" />
     <None Include="version.json" />
   </ItemGroup>
   <Import Project="$(NuProjPath)\NuProj.targets" Condition="Exists('$(NuProjPath)\NuProj.targets')" />

--- a/src/CBT.UnifiedOutputDir/CBT.UnifiedOutputDir.nuproj
+++ b/src/CBT.UnifiedOutputDir/CBT.UnifiedOutputDir.nuproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Configuration">
+    <Description>Provides NuGet related build tasks for CBT.</Description>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <ProjectGuid>20b4c0c1-5c4e-4dd0-9994-d89e78c3b161</ProjectGuid>
+    <Tags>CBT Module NuGet</Tags>
+    <Title>CBT NuGet Module</Title>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.props))\build.props" />
+
+  <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
+
+  <ItemGroup>
+    <Content Include="CBT\Module\Build.props" />
+    <None Include="version.json" />
+  </ItemGroup>
+
+  <Import Project="$(NuProjPath)\NuProj.targets" Condition="Exists('$(NuProjPath)\NuProj.targets')" />
+</Project>

--- a/src/CBT.UnifiedOutputDir/CBT/Module/CBT.UnifiedOutputDir.props
+++ b/src/CBT.UnifiedOutputDir/CBT/Module/CBT.UnifiedOutputDir.props
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="$(CBTLocalBuildExtensionsPath)\Before.$(MSBuildThisFile)" Condition=" '$(CBTLocalBuildExtensionsPath)' != '' And Exists('$(CBTLocalBuildExtensionsPath)\Before.$(MSBuildThisFile)') " />
+
+  <Import Project="$(CBTModuleExtensionsPath)\Before.$(MSBuildThisFile)" Condition=" '$(CBTModuleExtensionsPath)' != '' And Exists('$(CBTModuleExtensionsPath)\Before.$(MSBuildThisFile)') " />
+
+  <PropertyGroup>
+
+    <!-- CBTSelfContainedBuildOutput indicates whether to isolate the build output on a per-project basis. -->
+    <CBTSelfContainedBuildOutput Condition="'$(CBTSelfContainedBuildOutput)' != ''">$([System.Convert]::ToBoolean($(CBTSelfContainedBuildOutput)))</CBTSelfContainedBuildOutput>
+    <CBTSelfContainedBuildOutput Condition="'$(CBTSelfContainedBuildOutput)' == ''">true</CBTSelfContainedBuildOutput>
+
+    <CBTIntermediateOutputRootDir Condition=" '$(CBTIntermediateOutputRootDir)'=='' ">$(EnlistmentRoot)\obj</CBTIntermediateOutputRootDir>
+
+    <BaseIntermediateOutputPath Condition=" '$(BaseIntermediateOutputPath)' =='' ">$(CBTIntermediateOutputRootDir)</BaseIntermediateOutputPath>
+    <!-- IntermediateOutputPath requires a trailing slash to prevent MSB8004 warning -->
+    <IntermediateOutputPath Condition=" '$(IntermediateOutputPath)' =='' ">$(BaseIntermediateOutputPath)\$(Platform)\$(Configuration)\$(MSBuildProjectFile)\</IntermediateOutputPath>
+
+    <!-- Ensure IntermediateOutputPath is unique in situations where project files have identical names such as traversal projects a.k.a. dirs.proj. -->
+    <CBTEnableHashedIntermediateOutputPath Condition="'$(CBTEnableHashedIntermediateOutputPath)'!=''">$([System.Convert]::ToBoolean($(CBTEnableHashedIntermediateOutputPath)))</CBTEnableHashedIntermediateOutputPath>
+    <CBTEnableHashedIntermediateOutputPath Condition="'$(CBTEnableHashedIntermediateOutputPath)'==''">true</CBTEnableHashedIntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(CBTEnableHashedIntermediateOutputPath)' == 'true'">$([System.IO.Path]::Combine($(IntermediateOutputPath),$(MSBuildProjectFullPath.SubString($(EnlistmentRoot.Length)).GetHashCode().ToString("X"))))\</IntermediateOutputPath>
+
+    <CBTOutputRootDir Condition=" '$(CBTOverrideBaseOutputPath)' != '' ">$(CBTOverrideBaseOutputPath)</CBTOutputRootDir>
+    <CBTOutputPathPlatformPart Condition="'$(CBTOutputPathPlatformPart)' == ''">$(Platform)</CBTOutputPathPlatformPart>
+    <CBTOutputRootDir Condition=" '$(CBTOutputRootDir)' == '' ">$(EnlistmentRoot)\bin\$(CBTOutputPathPlatformPart)\$(Configuration)</CBTOutputRootDir>
+    <CBTOutputRootDir>$(CBTOutputRootDir.TrimEnd({'\\'}))</CBTOutputRootDir>
+
+    <CBTRelativeOutputPathAppend Condition="'$(CBTRelativeOutputPathAppend)' == ''">$(MSBuildProjectName)</CBTRelativeOutputPathAppend>
+    <CBTRelativeOutputPath Condition="'$(CBTSelfContainedBuildOutput)' == 'true'">$([System.IO.Path]::Combine($(CBTRelativeOutputPath), $(CBTRelativeOutputPathAppend)))</CBTRelativeOutputPath>
+
+    <!-- These variables are the ones that the standard MSBuild targets recognize.  We override them here.  -->
+    <OutDir Condition=" '$(OutDir)' =='' ">$([System.IO.Path]::Combine($(CBTOutputRootDir), $(CBTRelativeOutputPath)))</OutDir>
+
+    <!-- OutDir requires a trailing slash to prevent MSB8004 warning -->
+    <OutDir>$(OutDir.TrimEnd("\\"))\</OutDir>
+    <!-- This ensures OutputPath always matches OutDir, especially when TFS overrides OutDir. -->
+    <OutputPath>$(OutDir)</OutputPath>
+  </PropertyGroup>
+
+  <Import Project="$(CBTModuleExtensionsPath)\After.$(MSBuildThisFile)" Condition=" '$(CBTModuleExtensionsPath)' != '' And Exists('$(CBTModuleExtensionsPath)\After.$(MSBuildThisFile)') " />
+
+  <Import Project="$(CBTLocalBuildExtensionsPath)\After.$(MSBuildThisFile)" Condition=" '$(CBTLocalBuildExtensionsPath)' != '' And Exists('$(CBTLocalBuildExtensionsPath)\After.$(MSBuildThisFile)') " />
+
+</Project>

--- a/src/CBT.UnifiedOutputDir/CBT/Module/build.props
+++ b/src/CBT.UnifiedOutputDir/CBT/Module/build.props
@@ -1,37 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
 
-    <!-- CBTSelfContainedBuildOutput indicates whether to isolate the build output on a per-project basis. -->
-    <CBTSelfContainedBuildOutput Condition="'$(CBTSelfContainedBuildOutput)' != ''">$([System.Convert]::ToBoolean($(CBTSelfContainedBuildOutput)))</CBTSelfContainedBuildOutput>
-    <CBTSelfContainedBuildOutput Condition="'$(CBTSelfContainedBuildOutput)' == ''">true</CBTSelfContainedBuildOutput>
-
-    <CBTIntermediateOutputRootDir Condition=" '$(CBTIntermediateOutputRootDir)'=='' ">$(EnlistmentRoot)\obj</CBTIntermediateOutputRootDir>
-
-    <BaseIntermediateOutputPath Condition=" '$(BaseIntermediateOutputPath)' =='' ">$(CBTIntermediateOutputRootDir)</BaseIntermediateOutputPath>
-    <!-- IntermediateOutputPath requires a trailing slash to prevent MSB8004 warning -->
-    <IntermediateOutputPath Condition=" '$(IntermediateOutputPath)' =='' ">$(BaseIntermediateOutputPath)\$(Platform)\$(Configuration)\$(MSBuildProjectFile)\</IntermediateOutputPath>
-
-    <!-- Ensure IntermediateOutputPath is unique in situations where project files have identical names such as traversal projects a.k.a. dirs.proj. -->
-    <CBTEnableHashedIntermediateOutputPath Condition="'$(CBTEnableHashedIntermediateOutputPath)'!=''">$([System.Convert]::ToBoolean($(CBTEnableHashedIntermediateOutputPath)))</CBTEnableHashedIntermediateOutputPath>
-    <CBTEnableHashedIntermediateOutputPath Condition="'$(CBTEnableHashedIntermediateOutputPath)'==''">true</CBTEnableHashedIntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(CBTEnableHashedIntermediateOutputPath)' == 'true'">$([System.IO.Path]::Combine($(IntermediateOutputPath),$(MSBuildProjectFullPath.SubString($(EnlistmentRoot.Length)).GetHashCode().ToString("X"))))\</IntermediateOutputPath>
-
-    <CBTOutputRootDir Condition=" '$(CBTOverrideBaseOutputPath)' != '' ">$(CBTOverrideBaseOutputPath)</CBTOutputRootDir>
-    <CBTOutputPathPlatformPart Condition="'$(CBTOutputPathPlatformPart)' == ''">$(Platform)</CBTOutputPathPlatformPart>
-    <CBTOutputRootDir Condition=" '$(CBTOutputRootDir)' == '' ">$(EnlistmentRoot)\bin\$(CBTOutputPathPlatformPart)\$(Configuration)</CBTOutputRootDir>
-    <CBTOutputRootDir>$(CBTOutputRootDir.TrimEnd({'\\'}))</CBTOutputRootDir>
-
-    <CBTRelativeOutputPathAppend Condition="'$(CBTRelativeOutputPathAppend)' == ''">$(MSBuildProjectName)</CBTRelativeOutputPathAppend>
-    <CBTRelativeOutputPath Condition="'$(CBTSelfContainedBuildOutput)' == 'true'">$([System.IO.Path]::Combine($(CBTRelativeOutputPath), $(CBTRelativeOutputPathAppend)))</CBTRelativeOutputPath>
-
-    <!-- These variables are the ones that the standard MSBuild targets recognize.  We override them here.  -->
-    <OutDir Condition=" '$(OutDir)' =='' ">$([System.IO.Path]::Combine($(CBTOutputRootDir), $(CBTRelativeOutputPath)))</OutDir>
-
-    <!-- OutDir requires a trailing slash to prevent MSB8004 warning -->
-    <OutDir>$(OutDir.TrimEnd("\\"))\</OutDir>
-    <!-- This ensures OutputPath always matches OutDir, especially when TFS overrides OutDir. -->
-    <OutputPath>$(OutDir)</OutputPath>
-  </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)\CBT.UnifiedOutputDir.props"/>
 
 </Project>

--- a/src/CBT.UnifiedOutputDir/CBT/Module/build.props
+++ b/src/CBT.UnifiedOutputDir/CBT/Module/build.props
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+
+    <!-- CBTSelfContainedBuildOutput indicates whether to isolate the build output on a per-project basis. -->
+    <CBTSelfContainedBuildOutput Condition="'$(CBTSelfContainedBuildOutput)' != ''">$([System.Convert]::ToBoolean($(CBTSelfContainedBuildOutput)))</CBTSelfContainedBuildOutput>
+    <CBTSelfContainedBuildOutput Condition="'$(CBTSelfContainedBuildOutput)' == ''">true</CBTSelfContainedBuildOutput>
+
+    <CBTIntermediateOutputRootDir Condition=" '$(CBTIntermediateOutputRootDir)'=='' ">$(EnlistmentRoot)\obj</CBTIntermediateOutputRootDir>
+
+    <BaseIntermediateOutputPath Condition=" '$(BaseIntermediateOutputPath)' =='' ">$(CBTIntermediateOutputRootDir)</BaseIntermediateOutputPath>
+    <!-- IntermediateOutputPath requires a trailing slash to prevent MSB8004 warning -->
+    <IntermediateOutputPath Condition=" '$(IntermediateOutputPath)' =='' ">$(BaseIntermediateOutputPath)\$(Platform)\$(Configuration)\$(MSBuildProjectFile)\</IntermediateOutputPath>
+
+    <!-- Ensure IntermediateOutputPath is unique in situations where project files have identical names such as traversal projects a.k.a. dirs.proj. -->
+    <CBTEnableHashedIntermediateOutputPath Condition="'$(CBTEnableHashedIntermediateOutputPath)'!=''">$([System.Convert]::ToBoolean($(CBTEnableHashedIntermediateOutputPath)))</CBTEnableHashedIntermediateOutputPath>
+    <CBTEnableHashedIntermediateOutputPath Condition="'$(CBTEnableHashedIntermediateOutputPath)'==''">true</CBTEnableHashedIntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(CBTEnableHashedIntermediateOutputPath)' == 'true'">$([System.IO.Path]::Combine($(IntermediateOutputPath),$(MSBuildProjectFullPath.SubString($(EnlistmentRoot.Length)).GetHashCode().ToString("X"))))\</IntermediateOutputPath>
+
+    <CBTOutputRootDir Condition=" '$(CBTOverrideBaseOutputPath)' != '' ">$(CBTOverrideBaseOutputPath)</CBTOutputRootDir>
+    <CBTOutputPathPlatformPart Condition="'$(CBTOutputPathPlatformPart)' == ''">$(Platform)</CBTOutputPathPlatformPart>
+    <CBTOutputRootDir Condition=" '$(CBTOutputRootDir)' == '' ">$(EnlistmentRoot)\bin\$(CBTOutputPathPlatformPart)\$(Configuration)</CBTOutputRootDir>
+    <CBTOutputRootDir>$(CBTOutputRootDir.TrimEnd({'\\'}))</CBTOutputRootDir>
+
+    <CBTRelativeOutputPathAppend Condition="'$(CBTRelativeOutputPathAppend)' == ''">$(MSBuildProjectName)</CBTRelativeOutputPathAppend>
+    <CBTRelativeOutputPath Condition="'$(CBTSelfContainedBuildOutput)' == 'true'">$([System.IO.Path]::Combine($(CBTRelativeOutputPath), $(CBTRelativeOutputPathAppend)))</CBTRelativeOutputPath>
+
+    <!-- These variables are the ones that the standard MSBuild targets recognize.  We override them here.  -->
+    <OutDir Condition=" '$(OutDir)' =='' ">$([System.IO.Path]::Combine($(CBTOutputRootDir), $(CBTRelativeOutputPath)))</OutDir>
+
+    <!-- OutDir requires a trailing slash to prevent MSB8004 warning -->
+    <OutDir>$(OutDir.TrimEnd("\\"))\</OutDir>
+    <!-- This ensures OutputPath always matches OutDir, especially when TFS overrides OutDir. -->
+    <OutputPath>$(OutDir)</OutputPath>
+  </PropertyGroup>
+
+</Project>

--- a/src/CBT.UnifiedOutputDir/CBT/Module/module.config
+++ b/src/CBT.UnifiedOutputDir/CBT/Module/module.config
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<configuration>
+  <extensionImports>
+    <add name="Before.CBT.UnifiedOutputDir.props" />
+    <add name="After.CBT.UnifiedOutputDir.props" />
+  </extensionImports>
+</configuration>

--- a/src/CBT.UnifiedOutputDir/version.json
+++ b/src/CBT.UnifiedOutputDir/version.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "1.0-dev",
+  "buildNumberOffset": 1,
+  "publicReleaseRefSpec": [
+    "^refs/tags/CBT\\.UnifiedOutputDir.*"
+  ],
+  "cloudBuild": {
+    "setVersionVariables": false
+  }
+}


### PR DESCRIPTION
This creates a module that will unify the build output to the root bin and obj folder.
The only intermediate output that isn't handled by this is the module restoration obj location.  But that is ok the user can set that in their before.any.props or allow it to be placed in their system temp.

There are  number of scenarios I didn't add to this output that address specific bugs/issues with VS.

1.  For web projects when the output is out of the project dir the below blurb is used.
   &lt;PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true' and '$(UseWPP_CopyWebApplication)' == 'true' "&gt;
    &lt;!-- All of this ensures that we always publish on build, and use the .release and .debug variants of web.config. --&gt;
    &lt;WebProjectOutputDirInsideProject&gt;False&lt;/WebProjectOutputDirInsideProject&gt;
    &lt;PipelineDependsOnBuild&gt;False&lt;/PipelineDependsOnBuild&gt;
    &lt;!-- This is required for the _WPPCopyWebApplication target that creates _PublishedWebsites to execute. It only executes when OutDir != OutputPath, therefore adding noop path to make them appear different. --&gt;
    &lt;OutDir&gt;$(OutputPath)NoOp\..\&lt;/OutDir&gt;
  &lt;/PropertyGroup&gt;

2.  When building in VS for certain project types it requires the bits to be in the bin folder under the msbuildprojectdirectory  This is also needed for certain debugging scenarios.
  &lt;PropertyGroup Condition="'$(RedirectOutputToLocalBin)'=='' "&gt;
    &lt;!-- If we are in vs, we want to build web applications to bin, where vs expects to find them. --&gt;
    &lt;RedirectOutputToLocalBin Condition="'$(BuildingInsideVisualStudio)' == 'true' and $(ProjectTypeGuids.ToLower().Contains('{349c5851-65df-11da-9384-00065b846f21}'))"&gt;true&lt;/RedirectOutputToLocalBin&gt;
    &lt;!-- If we are in vs, we want to build 'Windows Phone 8/8.1 App (C#)' applications to bin, where vs expects to find them. --&gt;
    &lt;RedirectOutputToLocalBin Condition="'$(BuildingInsideVisualStudio)' == 'true' and $(ProjectTypeGuids.ToLower().Contains('{C089C8C0-30E0-4E22-80C0-CE093F111A43}'))"&gt;true&lt;/RedirectOutputToLocalBin&gt;
    &lt;!-- If we are in vs, we want to build 'Windows Phone 8/8.1 App (VB.NET)' applications to bin, where vs expects to find them. --&gt;
    &lt;RedirectOutputToLocalBin Condition="'$(BuildingInsideVisualStudio)' == 'true' and $(ProjectTypeGuids.ToLower().Contains('{DB03555F-0C8B-43BE-9FF9-57896B3C5E56}'))"&gt;true&lt;/RedirectOutputToLocalBin&gt;
    &lt;!-- If we are in vs, we want to build 'Windows Phone 8/8.1 Blank/Hub/Webview App' applications to bin, where vs expects to find them. --&gt;
    &lt;RedirectOutputToLocalBin Condition="'$(BuildingInsideVisualStudio)' == 'true' and $(ProjectTypeGuids.ToLower().Contains('{76F1466A-8B6D-4E39-A767-685A06062A39}'))"&gt;true&lt;/RedirectOutputToLocalBin&gt;
    &lt;RedirectOutputToLocalBin Condition="'$(RedirectOutputToLocalBin)'==''"&gt;false&lt;/RedirectOutputToLocalBin&gt;
  &lt;/PropertyGroup&gt;

  &lt;PropertyGroup Condition="'$(RedirectOutputToLocalBin)'=='true'"&gt;
    &lt;OutputPath&gt;bin\&lt;/OutputPath&gt;
    &lt;OutDir&gt;&lt;/OutDir&gt;
  &lt;/PropertyGroup&gt;

3.  When running codeanalysis under VS there is an issue where the intermediate output dir can sometimes be hard coded to be obj under the msbuildprojectdirectory folder.
In that scenario we just didn't customize the obj folder.


The hope is that we can find better solutions for these problems a they and others invariably come up.
