### PR TITLE
Add GetNativeManifest 

### DIFF
--- a/src/CBT.Traversal/CBT/Module/Traversal.targets
+++ b/src/CBT.Traversal/CBT/Module/Traversal.targets
@@ -10,6 +10,9 @@
     </RebuildDependsOn>
   </PropertyGroup>
 
+  <!-- This is necessary when a project takes a ProjectReference on a dirs.proj for build ordering as ResolveProjectReference from the default CSharp targets expects this target to exist. -->
+  <Target Name="GetNativeManifest" />
+
   <Import Project="$(CustomBeforeTraversalTargets)" Condition=" '$(CustomBeforeTraversalTargets)' != '' And Exists('$(CustomBeforeTraversalTargets)') " />
 
   <Import Project="$(CBTLocalBuildExtensionsPath)\Before.$(MSBuildThisFile)" Condition=" '$(CBTLocalBuildExtensionsPath)' != '' And Exists('$(CBTLocalBuildExtensionsPath)\Before.$(MSBuildThisFile)') " />


### PR DESCRIPTION
If someone takes a &lt;ProjectReference on a dirs.proj it will break since the default resolve reference task requires the GetNativeManifest target to be defined for every project.