### PR TITLE
Move version properties into props instead of targets

### DIFF
--- a/src/CBT.AssemblyInfo/CBT/Module/AssemblyInfo.targets
+++ b/src/CBT.AssemblyInfo/CBT/Module/AssemblyInfo.targets
@@ -17,19 +17,6 @@
     <AssemblyInfoAllProjects>$(AssemblyInfoAllProjects);$(MSBuildThisFileFullPath);$(MSBuildProjectFullPath)</AssemblyInfoAllProjects>
     <AssemblyInfoAllProjects Condition=" '$(CBTLocalBuildExtensionsPath)' != '' And Exists('$(CBTLocalBuildExtensionsPath)\AssemblyInfo.props') ">$(AssemblyInfoAllProjects);$(CBTLocalBuildExtensionsPath)\AssemblyInfo.props</AssemblyInfoAllProjects>
 
-    <!-- Please use international format yyyy-mm-dd -->
-    <VersionBuildNumberStartDate Condition="'$(VersionBuildNumberStartDate)' == ''">$([System.DateTime]::Now.ToString("yyyy-MM-dd"))</VersionBuildNumberStartDate>
-
-    <!--
-    Note: when changing VersionMajor or VersionMinor, you probably want to also reset the VersionBuildNumberStartDate:
-    - If you want to reset the build number to zero: set VersionBuildNumberStartDate to current date
-    - If you want to reset the build number to say 1000: set VersionBuildNumberStartDate to 1000 days in the past.
-      Here's how one would figure out what date it was 1000 days ago in PowerShell: Write-Host (Get-Date).AddDays(-1000)
-    -->
-    <VersionMajor Condition=" '$(VersionMajor)' == '' ">1</VersionMajor>
-    <VersionMinor Condition=" '$(VersionMinor)' == '' ">0</VersionMinor>
-    <VersionBuildNumber Condition=" '$(VersionBuildNumber)' == '' ">$([System.DateTime]::Now.Subtract($([System.DateTime]::Parse($(VersionBuildNumberStartDate)))).Days)</VersionBuildNumber>
-    <VersionBuildRevision Condition=" '$(VersionBuildRevision)' == '' ">0</VersionBuildRevision>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Language)' == 'C#' Or '$(Language)' == 'VB' ">
@@ -74,14 +61,6 @@
   <Target Name="DetermineAssemblyVersionInfo"
     DependsOnTargets="$(DetermineAssemblyVersionInfoDependsOn)">
 
-    <PropertyGroup>
-      <VersionFull Condition=" '$(VersionFull)' == '' ">$(VersionMajor).$(VersionMinor).$(VersionBuildNumber).$(VersionBuildRevision)</VersionFull>
-
-      <AssemblyInfoInformationalVersion Condition=" '$(AssemblyInfoInformationalVersion)' == '' ">$(VersionFull)$(VersionBuildLabel)</AssemblyInfoInformationalVersion>
-      <AssemblyInfoVersion Condition=" '$(AssemblyInfoVersion)' == '' ">$(VersionMajor).$(VersionMinor).0.0</AssemblyInfoVersion>
-      <AssemblyInfoFileVersion Condition=" '$(AssemblyInfoFileVersion)' == '' ">$(VersionFull)</AssemblyInfoFileVersion>
-    </PropertyGroup>
-
     <ItemGroup>
       <AssemblyInfoTemplateFile>
         <AssemblyInfoFileVersion>$(AssemblyInfoFileVersion)</AssemblyInfoFileVersion>
@@ -89,10 +68,10 @@
         <AssemblyInfoInternalName>$(AssemblyInfoInternalName)</AssemblyInfoInternalName>
         <AssemblyInfoOriginalFileName>$(AssemblyInfoOriginalFileName)</AssemblyInfoOriginalFileName>
         <AssemblyInfoInformationalVersion>$(AssemblyInfoInformationalVersion)</AssemblyInfoInformationalVersion>
-        <AssemblyInfoVersion>$(AssemblyInfoVersion)</AssemblyInfoVersion>
+        <AssemblyInfoAssemblyVersion>$(AssemblyInfoAssemblyVersion)</AssemblyInfoAssemblyVersion>
 
         <!-- Override the output file to include the version so that the project will be rebuilt if it changes -->
-        <OutputFileHash>%(AssemblyInfoTemplateFile.OutputFileHash);$(VersionFull)</OutputFileHash>
+        <OutputFileHash>%(AssemblyInfoTemplateFile.OutputFileHash);$(Version4PartVersion)</OutputFileHash>
       </AssemblyInfoTemplateFile>
     </ItemGroup>
 

--- a/src/CBT.AssemblyInfo/CBT/Module/Build.props
+++ b/src/CBT.AssemblyInfo/CBT/Module/Build.props
@@ -8,4 +8,24 @@
   <PropertyGroup Condition=" '$(EnableCBTAssemblyInfoGeneration)' == 'true' ">
     <GenerateTargetFrameworkAttribute Condition=" '$(GenerateTargetFrameworkAttribute)' == '' ">false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Please use international format yyyy-mm-dd -->
+    <VersionBuildNumberStartDate Condition=" '$(VersionBuildNumberStartDate)' == '' ">$([System.DateTime]::Now.ToString("yyyy-MM-dd"))</VersionBuildNumberStartDate>
+
+    <!--
+    Note: when changing VersionMajor or VersionMinor, you probably want to also reset the VersionBuildNumberStartDate:
+    - If you want to reset the build number to zero: set VersionBuildNumberStartDate to current date
+    - If you want to reset the build number to say 1000: set VersionBuildNumberStartDate to 1000 days in the past.
+      Here's how one would figure out what date it was 1000 days ago in PowerShell: Write-Host (Get-Date).AddDays(-1000)
+    -->
+    <VersionMajor Condition=" '$(VersionMajor)' == '' ">1</VersionMajor>
+    <VersionMinor Condition=" '$(VersionMinor)' == '' ">0</VersionMinor>
+    <VersionBuildNumber Condition=" '$(VersionBuildNumber)' == '' ">$([System.DateTime]::Now.Subtract($([System.DateTime]::Parse($(VersionBuildNumberStartDate)))).Days)</VersionBuildNumber>
+    <VersionBuildRevision Condition=" '$(VersionBuildRevision)' == '' ">0</VersionBuildRevision>
+    <Version4PartVersion Condition=" '$(Version4PartVersion)' == '' ">$([System.Version]::new($(VersionMajor).$(VersionMinor).$(VersionBuildNumber).$(VersionBuildRevision)))</Version4PartVersion>
+    <AssemblyInfoInformationalVersion Condition=" '$(AssemblyInfoInformationalVersion)' == '' ">$(Version4PartVersion)$(VersionBuildLabel)</AssemblyInfoInformationalVersion>
+    <AssemblyInfoAssemblyVersion Condition=" '$(AssemblyInfoAssemblyVersion)' == '' ">$(VersionMajor).$(VersionMinor).0.0</AssemblyInfoAssemblyVersion>
+    <AssemblyInfoFileVersion Condition=" '$(AssemblyInfoFileVersion)' == '' ">$(Version4PartVersion)</AssemblyInfoFileVersion>
+
+  </PropertyGroup>
 </Project>

--- a/src/CBT.AssemblyInfo/CBT/Module/Templates/AssemblyInfo.cs
+++ b/src/CBT.AssemblyInfo/CBT/Module/Templates/AssemblyInfo.cs
@@ -29,7 +29,7 @@ remove the conflicting assembly attribute defined in the project item Properties
 [assembly: AssemblyInformationalVersion("$(AssemblyInfoInformationalVersion)")]
 [assembly: AssemblyProduct("$(AssemblyInfoProduct)")]
 [assembly: AssemblyTrademark("$(AssemblyInfoTrademark)")]
-[assembly: AssemblyVersion("$(AssemblyInfoVersion)")]
+[assembly: AssemblyVersion("$(AssemblyInfoAssemblyVersion)")]
 [assembly: CLSCompliant($(AssemblyInfoCLSCompliant))]
 [assembly: ComVisible($(AssemblyInfoComVisible))]
 [assembly: TargetFrameworkAttribute("$(AssemblyInfoTargetFrameworkMoniker)", FrameworkDisplayName = "$(AssemblyInfoTargetFrameworkMonikerDisplayName)")]

--- a/src/CBT.AssemblyInfo/CBT/Module/Templates/AssemblyInfo.vb
+++ b/src/CBT.AssemblyInfo/CBT/Module/Templates/AssemblyInfo.vb
@@ -19,10 +19,10 @@ Imports System.Runtime.InteropServices
 <Assembly: AssemblyConfiguration("$(AssemblyInfoConfiguration)")>
 <Assembly: AssemblyCopyright("$(AssemblyInfoCopyright)")>
 <Assembly: AssemblyCulture("$(AssemblyInfoCulture)")>
-<Assembly: AssemblyFileVersion("%AssemblyFileVersion%")> 
-<Assembly: AssemblyInformationalVersion("%AssemblyInformationalVersion%")>
+<Assembly: AssemblyFileVersion("$(AssemblyInfoFileVersion)")>
+<Assembly: AssemblyInformationalVersion("$(AssemblyInfoInformationalVersion)")>
 <Assembly: AssemblyProduct("$(AssemblyInfoProduct)")>
 <Assembly: AssemblyTrademark("$(AssemblyInfoTrademark)")>
-<Assembly: AssemblyVersion("%AssemblyVersion%")> 
+<Assembly: AssemblyVersion("$(AssemblyInfoAssemblyVersion)")>
 <Assembly: CLSCompliant($(AssemblyInfoCLSCompliant))>
 <Assembly: ComVisible($(AssemblyInfoComVisible))>


### PR DESCRIPTION
version properties are sometimes needed for consumption before target execution.  

This will create version properties as part of the build.props extension import allowing the user to reference and use them immediately after the import of the build.props.

VB projects appear to be busted in general with CBT.  I have created a separate issue to track that.