### PR TITLE
Fixes for recent 2.1 functionality

### DIFF
--- a/src/CBT.NuGet.GlobalRestore/build/Before.CBT.NuGet.PackageProperties.props
+++ b/src/CBT.NuGet.GlobalRestore/build/Before.CBT.NuGet.PackageProperties.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <CBTEnableGlobalPackageRestore Condition=" '$(CBTEnablePackageRestore)' == 'false' ">false</CBTEnableGlobalPackageRestore>
+    <CBTEnableGlobalPackageRestore Condition=" '$(CBTEnablePackageRestore)' == 'false' And '$(IsTraversal)' != 'true' ">false</CBTEnableGlobalPackageRestore>
     <CBTEnableGlobalPackageRestore Condition=" '$(ExcludeRestorePackageImports)' == 'true' ">false</CBTEnableGlobalPackageRestore>
     <CBTEnableGlobalPackageRestore Condition=" '$(CBTEnableGlobalPackageRestore)' == '' ">true</CBTEnableGlobalPackageRestore>
   </PropertyGroup>

--- a/src/CBT.NuGet.Package/build/After.Traversal.targets
+++ b/src/CBT.NuGet.Package/build/After.Traversal.targets
@@ -10,21 +10,17 @@
   </PropertyGroup>
 
 
-<PropertyGroup Condition=" '$(CBTEnableNuGetPackageRestoreOptimization)' != 'false' And '$(CBTNuGetTraversalPackagesRestored)' != 'true' And '$(ExcludeRestorePackageImports)' != 'true' ">
-    <CBTNuGetTraversalPackagesRestored Condition=" '$(CBTNuGetTasksAssemblyName)' != '' ">$(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType('System.AppDomain').GetProperty('CurrentDomain').GetValue(null).GetData(`CBT_NUGET_ASSEMBLY`).CreateInstance('CBT.NuGet.Tasks.TraversalNuGetRestore').Execute($(CBTNuGetTraversalRestoreFile), '$(NuGetMsBuildVersion)', $(CBTNuGetRestorePackagesDirectory), $(CBTNuGetRestoreRequireConsent), $(NuGetRestoreSolutionDirectory), $(CBTNuGetDisableParallelProcessing), $(NuGetFallbackSource.Split(';')), $(CBTNuGetNoCache), $(NuGetPackageSaveMode), $(NuGetSource.Split(';')), $(NuGetConfigFile), $(CBTNuGetNonInteractive), $(NuGetVerbosity), $(CBTNuGetTimeout), $(CBTNuGetPath), $([MSBuild]::ValueOrDefault('$(CBTEnableNuGetPackageRestoreOptimization)', 'true')), $(CBTNuGetTraversalPackagesRestoredMarker), $(CBTNuGetAllProjects.Split(';')), $(MSBuildToolsVersion), $(MSBuildProjectFullPath), $(CBTNuGetTraversalRestoreGlobalProperties), '$(NuGetMsBuildPath)', '$(CBTNuGetRestoreAdditionalArguments)'))</CBTNuGetTraversalPackagesRestored>
+  <PropertyGroup Condition=" '$(CBTEnableNuGetPackageRestoreOptimization)' != 'false' And '$(CBTNuGetTraversalPackagesRestored)' != 'true' And '$(ExcludeRestorePackageImports)' != 'true' ">
+    <CBTNuGetTraversalPackagesRestored Condition=" '$(CBTNuGetTasksAssemblyName)' != '' ">$(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType('System.AppDomain').GetProperty('CurrentDomain').GetValue(null).GetData(`CBT_NUGET_ASSEMBLY`).CreateInstance('CBT.NuGet.Tasks.TraversalNuGetRestore').Execute($(CBTNuGetTraversalRestoreFile), '$(NuGetMsBuildVersion)', $(CBTNuGetRestoreRequireConsent), $(CBTNuGetDisableParallelProcessing), $(NuGetFallbackSource.Split(';')), $(CBTNuGetNoCache), $(NuGetPackageSaveMode), $(NuGetSource.Split(';')), $(NuGetConfigFile), $(CBTNuGetNonInteractive), $(NuGetVerbosity), $(CBTNuGetTimeout), $(CBTNuGetPath), $([MSBuild]::ValueOrDefault('$(CBTEnableNuGetPackageRestoreOptimization)', 'true')), $(CBTNuGetTraversalPackagesRestoredMarker), $(CBTNuGetAllProjects.Split(';')), $(MSBuildToolsVersion), $(MSBuildProjectFullPath), $(CBTNuGetTraversalRestoreGlobalProperties), '$(NuGetMsBuildPath)', '$(CBTNuGetRestoreAdditionalArguments)'))</CBTNuGetTraversalPackagesRestored>
     <TraversalGlobalProperties>$(TraversalGlobalProperties);CBTNuGetTraversalPackagesRestored=$(CBTNuGetTraversalPackagesRestored)</TraversalGlobalProperties>
-    <CBTNuGetTraversalPackagePropertiesCreated Condition=" '$(CBTNuGetTraversalPackagesRestored)' == 'true'  And '$(CBTNuGetTasksAssemblyName)' != '' ">$(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType('System.AppDomain').GetProperty('CurrentDomain').GetValue(null).GetData(`CBT_NUGET_ASSEMBLY`).CreateInstance('CBT.NuGet.Tasks.GenerateNuGetProperties').Execute($(CBTNuGetTraversalRestoreFile), $(CBTNuGetAllProjects.Split(';')), $(CBTNuGetTraversalPackagePropertyFile), $(CBTNuGetPackagePropertyVersionNamePrefix), $(CBTNuGetPackagePropertyPathNamePrefix), '$(CBTNuGetRestorePackagesDirectory)', '$(CBTNuGetAssetsFlagFile)'))</CBTNuGetTraversalPackagePropertiesCreated>
+    <!-- Disable the Restore target in Traversal.targets so that we don't call Restore for every project in the tree -->
+    <EnableProjectRestore Condition=" '$(EnableProjectRestore)' == '' ">false</EnableProjectRestore>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <CBTParseError Condition=" '$(CBTNuGetTraversalPackagesRestored)' == 'false' " Include="Traversal packages were not restored and the build cannot continue.  Refer to other errors for more information.">
       <Code>CBT.NuGet.1003</Code>
     </CBTParseError>
-    <CBTParseError Condition=" '$(CBTNuGetTraversalPackagePropertiesCreated)' == 'false' " Include="Traversal package properties were not created and the build cannot continue.  Refer to other errors for more information.">
-      <Code>CBT.NuGet.1004</Code>
-    </CBTParseError>
   </ItemGroup>
 
-  <Import Project="$(CBTNuGetTraversalPackagePropertyFile)" Condition=" '$(CBTNuGetTraversalPackagePropertiesCreated)' == 'true' "/>
-  
 </Project>

--- a/src/CBT.NuGet.Package/build/CBT.NuGet.props
+++ b/src/CBT.NuGet.Package/build/CBT.NuGet.props
@@ -103,7 +103,7 @@
   <!--
     Import NuGet package properties
   -->
-  <Import Project="$(CBTNuGetPackagePropertyFile)" Condition=" '$(CBTNuGetPackagePropertiesCreated)' == 'true' Or Exists('$(CBTNuGetPackagePropertyFile)') "/>
+  <Import Project="$(CBTNuGetPackagePropertyFile)" Condition=" Exists('$(CBTNuGetPackagePropertyFile)') "/>
 
   <!--
     Import After.CBT.NuGet.PackageProperties from module extensions and then local extensions

--- a/src/CBT.NuGet/Internal/NuGetPropertyGenerator.cs
+++ b/src/CBT.NuGet/Internal/NuGetPropertyGenerator.cs
@@ -43,6 +43,13 @@ namespace CBT.NuGet.Internal
 
         public bool Generate(string outputPath, string propertyVersionNamePrefix, string propertyPathNamePrefix, PackageRestoreData restoreData)
         {
+            // Delete an existing file in case there are no properties generated and we don't end up saving the file
+            //
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+
             ProjectRootElement project = ProjectRootElement.Create();
             ProjectPropertyGroupElement propertyGroup = project.AddPropertyGroup();
             propertyGroup.SetProperty("MSBuildAllProjects", "$(MSBuildAllProjects);$(MSBuildThisFileFullPath)");

--- a/src/CBT.NuGet/Tasks/GenerateNuGetProperties.cs
+++ b/src/CBT.NuGet/Tasks/GenerateNuGetProperties.cs
@@ -96,8 +96,8 @@ namespace CBT.NuGet.Tasks
         {
             Log.LogMessage(MessageImportance.Low, "Generating MSBuild property file '{0}' for NuGet packages", PropsFile);
             NuGetPropertyGenerator nuGetPropertyGenerator = new NuGetPropertyGenerator(_log, PackageRestoreFile);
-            nuGetPropertyGenerator.Generate(PropsFile, PropertyVersionNamePrefix, PropertyPathNamePrefix, GetPackageRestoreData());
-            return true;
+            
+            return nuGetPropertyGenerator.Generate(PropsFile, PropertyVersionNamePrefix, PropertyPathNamePrefix, GetPackageRestoreData());
         }
 
         public bool Execute(string packageRestoreFile, string[] inputs, string propsFile, string propertyVersionNamePrefix, string propertyPathNamePrefix, string restoreInfoFile = "")

--- a/src/CBT.NuGet/Tasks/NuGetRestore.cs
+++ b/src/CBT.NuGet/Tasks/NuGetRestore.cs
@@ -125,9 +125,9 @@ namespace CBT.NuGet.Tasks
             if (enableOptimization && IsFileUpToDate(Log, markerPath, inputs))
             {
                 Log.LogMessage(MessageImportance.Low, "NuGet packages are up-to-date");
-
                 return true;
             }
+
             if (Directory.Exists(file))
             {
                 Log.LogMessage(MessageImportance.Low, $"A directory with the name '{file}' exist.  Please consider renaming this directory to avoid breaking nuget convention.");

--- a/src/CBT.NuGet/Tasks/TraversalNuGetRestore.cs
+++ b/src/CBT.NuGet/Tasks/TraversalNuGetRestore.cs
@@ -23,10 +23,17 @@ namespace CBT.NuGet.Tasks
             {
                 BuildEngine = new CBTBuildEngine();
             }
+            
             MSBuildToolsVersion = msbuildToolsVersion;
             Project = project;
             GlobalProperties = globalProperties;
             File = file;
+
+            if (enableOptimization && IsFileUpToDate(Log, markerPath, inputs))
+            {
+                Log.LogMessage(MessageImportance.Low, "Traversal NuGet packages are up-to-date");
+                return true;
+            }
 
             MSBuildProjectLoader projectLoader = new MSBuildProjectLoader(GlobalProperties.Split(new[] {';', ','}, StringSplitOptions.RemoveEmptyEntries).Where(i => !String.IsNullOrWhiteSpace(i)).Select(i => i.Trim().Split(new[] {'='}, 2, StringSplitOptions.RemoveEmptyEntries)).ToDictionary(i => i.First(), i => i.Last()), MSBuildToolsVersion, Log, ProjectLoadSettings.IgnoreMissingImports);
 

--- a/src/CBT.Traversal/build/Traversal.targets
+++ b/src/CBT.Traversal/build/Traversal.targets
@@ -50,7 +50,7 @@
 
   <Target Name="Rebuild" DependsOnTargets="$(RebuildDependsOn)" />
 
-  <Target Name="Restore" DependsOnTargets="$(RestoreDependsOn)">
+  <Target Name="Restore" DependsOnTargets="$(RestoreDependsOn)" Condition=" '$(EnableProjectRestore)' != 'false' ">
     <MSBuild Projects="@(PreTraversalProjectFile)" Targets="Restore" Condition=" '@(PreTraversalProjectFile)' != '' " />
 
     <MSBuild Projects="@(ProjectFile)" Targets="Restore" BuildInParallel="$(BuildInParallel)" SkipNonexistentProjects="$(SkipNonexistentProjects)" Properties="CBTModulesRestored=$(CBTModulesRestored);IsRestoreOnly=true;$(TraversalGlobalProperties);$(TraversalRestoreGlobalProperties)" />


### PR DESCRIPTION
Enable Global Restore during traversal restore
Disable property generation during traversal restore
Disable project restore during traversal restore
Import NuGet package properties based on existence only
Optimize traversal restore by checking inputs/outputs in the super class