### PR TITLE
Use more semaphores in CBT.NuGet

### DIFF
--- a/src/CBT.NuGet/Tasks/ImportBuildPackages.cs
+++ b/src/CBT.NuGet/Tasks/ImportBuildPackages.cs
@@ -43,9 +43,7 @@ namespace CBT.NuGet.Tasks
 
             string semaphoreName = PropsFile.ToUpper().GetHashCode().ToString("X");
 
-            bool releaseSemaphore;
-
-            using (Semaphore semaphore = new Semaphore(0, 1, semaphoreName, out releaseSemaphore))
+            using (Semaphore semaphore = new Semaphore(0, 1, semaphoreName, out bool releaseSemaphore))
             {
                 try
                 {


### PR DESCRIPTION
Use a semaphore in `AggregatePackages` and `GenerateNuGetProperties`.

Add new `ExecutePostRestore()` method in `NuGetRestore` so that `TraversalNuGetRestore` can execute actions inside of the super class' semaphore.

Other general cleanup