### PR TITLE
Generate NuGet package properties during traversal restore

### DIFF
--- a/src/CBT.NuGet.Package/CBT.NuGet.Package.nuproj
+++ b/src/CBT.NuGet.Package/CBT.NuGet.Package.nuproj
@@ -19,6 +19,7 @@
     <Dependency Include="CBT.Traversal">
       <Version>[2.0.40,)</Version>
     </Dependency>
+    <Content Include="build\RestoreOnly.targets" />
     <Content Include="build\After.Microsoft.Common.targets" />
     <Content Include="build\After.Traversal.targets" />
     <Content Include="build\module.config" />

--- a/src/CBT.NuGet.Package/build/After.Microsoft.Common.targets
+++ b/src/CBT.NuGet.Package/build/After.Microsoft.Common.targets
@@ -1,18 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project InitialTargets="GenerateNuGetProperties" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project InitialTargets="GenerateNuGetPropertiesInsideVisualStudio" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <PrepareForBuildDependsOn Condition=" '$(CBTEnableNuGetPackageRestoreOptimization)' != 'false' ">_CheckForCBTNuGetPackagesRestoredMarker;$(PrepareForBuildDependsOn)</PrepareForBuildDependsOn>
-    <RestoreDependsOn>RestoreNuGetPackages;$(RestoreDependsOn)</RestoreDependsOn>
+    <RestoreDependsOn>$(RestoreDependsOn);RestoreNuGetPackages</RestoreDependsOn>
+    <RestoreDependsOn Condition=" '$(CBTNuGetGeneratePackageProperties)' != 'false' ">$(RestoreDependsOn);GenerateNuGetProperties</RestoreDependsOn>
   </PropertyGroup>
 
   <Import Project="$(NuGetTargets)" Condition=" '$(NuGetTargets)' != '' And !Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.targets\ImportAfter\Microsoft.NuGet.ImportAfter.targets') " />
 
   <Import Project="$(CBTBuildPackageTargetsFile)" Condition=" '$(CBTEnableImportBuildPackages)' != 'false' "/>
 
-  <Target Name="GenerateNuGetProperties"
+  <!--
+  This target generates NuGet package properties when the project is loaded in Visual Studio.  Design-time builds are called
+  a few times and eventually RestoreSuccess is 'true' so properties can be created.
+  -->
+  <Target Name="GenerateNuGetPropertiesInsideVisualStudio"
     Condition=" '$(BuildingInsideVisualStudio)' == 'true' And '$(RestoreSuccess)' == 'true' "
-    DependsOnTargets="GenerateNuGetAssetFlagFileInVisualStudio"
+    DependsOnTargets="GenerateNuGetAssetFlagFileInsideVisualStudio"
     Inputs="$(CBTNuGetAllProjects);$(CBTNuGetRestoreFile)"
     Outputs="$(CBTNuGetPackagePropertyFile)">
 
@@ -27,7 +32,7 @@
     />
   </Target>
 
-  <Target Name="GenerateNuGetAssetFlagFileInVisualStudio"
+  <Target Name="GenerateNuGetAssetFlagFileInsideVisualStudio"
     Condition=" '$(BuildingInsideVisualStudio)' == 'true' "
     Inputs="$(CBTNuGetRestoreFile)"
     Outputs="$(CBTNuGetAssetsFlagFile)">
@@ -60,5 +65,28 @@
     <WriteNuGetRestoreInfo File="$(CBTNuGetAssetsFlagFile)" Input="@(RestoreAssetsFlagData)" />
     
   </Target>
+
+  
+  <!--
+  This target only runs during traversal restore because the stock Restore target has no DependsOn set, command-line builds
+  do restore as part of property evaluation, and Visual Studio based builds run the GenerateNuGetPropertiesInsideVisualStudio
+  target instead.
+  -->
+  <Target Name="GenerateNuGetProperties"
+          Condition=" '$(CBTNuGetGeneratePackageProperties)' == 'true' "
+          Inputs="$(CBTNuGetAllProjects);$(CBTNuGetRestoreFile)"
+          Outputs="$(CBTNuGetPackagePropertyFile)">
+
+    <GenerateNuGetProperties
+      PackageRestoreFile="$(CBTNuGetRestoreFile)"
+      Inputs="$(CBTNuGetAllProjects.Split(';'))"
+      PropsFile="$(CBTNuGetPackagePropertyFile)"
+      PropertyVersionNamePrefix="$(CBTNuGetPackagePropertyVersionNamePrefix)"
+      PropertyPathNamePrefix="$(CBTNuGetPackagePropertyPathNamePrefix)"
+      RestoreInfoFile="$(CBTNuGetAssetsFlagFile)"
+    />
+  </Target>
+
+  <Import Project="RestoreOnly.targets" Condition=" '$(IsRestoreOnly)' == 'true' " />
   
 </Project>

--- a/src/CBT.NuGet.Package/build/After.Traversal.targets
+++ b/src/CBT.NuGet.Package/build/After.Traversal.targets
@@ -6,15 +6,14 @@
     <CBTNuGetTraversalPackagesRestoredMarker Condition=" '$(CBTNuGetTraversalPackagesRestoredMarker)' == '' ">$(CBTNuGetIntermediateOutputPath)\$(MSBuildProjectFile).CBTNuGetTraversalPackagesRestored</CBTNuGetTraversalPackagesRestoredMarker>
     <CBTNuGetTraversalPackagePropertyFile Condition=" '$(CBTNuGetTraversalPackagePropertyFile)' == '' ">$(CBTNuGetTraversalRestoreFile).props</CBTNuGetTraversalPackagePropertyFile>
     <CBTNuGetAllProjects>$(MSBuildProjectFullPath);$(MSBuildThisFileFullPath);$(CBTNuGetAllProjects)</CBTNuGetAllProjects>
-    <CBTNuGetTraversalRestoreGlobalProperties Condition=" '$(CBTNuGetTraversalRestoreGlobalProperties)' == '' ">BuildingInsideVisualStudio=true;DesignTimeBuild=true;CBTModulesRestored=true;CBTNuGetGeneratePackageProperties=false;CBTNuGetTraversalPackagePropertiesCreated=true;CBTNuGetTraversalPackagesRestored=true</CBTNuGetTraversalRestoreGlobalProperties>
+    <CBTNuGetTraversalRestoreGlobalProperties Condition=" '$(CBTNuGetTraversalRestoreGlobalProperties)' == '' ">BuildingInsideVisualStudio=true;DesignTimeBuild=true;CBTModulesRestored=true;CBTNuGetTraversalPackagesRestored=true</CBTNuGetTraversalRestoreGlobalProperties>
   </PropertyGroup>
 
 
   <PropertyGroup Condition=" '$(CBTEnableNuGetPackageRestoreOptimization)' != 'false' And '$(CBTNuGetTraversalPackagesRestored)' != 'true' And '$(ExcludeRestorePackageImports)' != 'true' ">
     <CBTNuGetTraversalPackagesRestored Condition=" '$(CBTNuGetTasksAssemblyName)' != '' ">$(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType('System.AppDomain').GetProperty('CurrentDomain').GetValue(null).GetData(`CBT_NUGET_ASSEMBLY`).CreateInstance('CBT.NuGet.Tasks.TraversalNuGetRestore').Execute($(CBTNuGetTraversalRestoreFile), '$(NuGetMsBuildVersion)', $(CBTNuGetRestoreRequireConsent), $(CBTNuGetDisableParallelProcessing), $(NuGetFallbackSource.Split(';')), $(CBTNuGetNoCache), $(NuGetPackageSaveMode), $(NuGetSource.Split(';')), $(NuGetConfigFile), $(CBTNuGetNonInteractive), $(NuGetVerbosity), $(CBTNuGetTimeout), $(CBTNuGetPath), $([MSBuild]::ValueOrDefault('$(CBTEnableNuGetPackageRestoreOptimization)', 'true')), $(CBTNuGetTraversalPackagesRestoredMarker), $(CBTNuGetAllProjects.Split(';')), $(MSBuildToolsVersion), $(MSBuildProjectFullPath), $(CBTNuGetTraversalRestoreGlobalProperties), '$(NuGetMSBuildPath)', '$(CBTNuGetRestoreAdditionalArguments)'))</CBTNuGetTraversalPackagesRestored>
     <TraversalGlobalProperties>$(TraversalGlobalProperties);CBTNuGetTraversalPackagesRestored=$(CBTNuGetTraversalPackagesRestored)</TraversalGlobalProperties>
-    <!-- Disable the Restore target in Traversal.targets so that we don't call Restore for every project in the tree -->
-    <EnableProjectRestore Condition=" '$(EnableProjectRestore)' == '' ">false</EnableProjectRestore>
+    <TraversalGlobalProperties>$(TraversalGlobalProperties);CBTNuGetPackagesRestored=$(CBTNuGetTraversalPackagesRestored)</TraversalGlobalProperties>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CBT.NuGet.Package/build/CBT.NuGet.props
+++ b/src/CBT.NuGet.Package/build/CBT.NuGet.props
@@ -71,7 +71,7 @@
     <CBTNuGetPackagesRestored Condition=" '$(CBTNuGetPackagesRestored)' == '' And '$(CBTNuGetTasksAssemblyName)' != '' ">$(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType('System.AppDomain').GetProperty('CurrentDomain').GetValue(null).GetData('CBT_NUGET_ASSEMBLY').CreateInstance('CBT.NuGet.Tasks.NuGetRestore').Execute($(CBTNuGetRestoreFile), '$(NuGetMsBuildVersion)', $(CBTNuGetRestoreRequireConsent), $(CBTNuGetDisableParallelProcessing), $(NuGetFallbackSource.Split(';')), $(CBTNuGetNoCache), $(NuGetPackageSaveMode), $(NuGetSource.Split(';')), $(NuGetConfigFile), $(CBTNuGetNonInteractive), $(NuGetVerbosity), $(CBTNuGetTimeout), $(CBTNuGetPath), $([MSBuild]::ValueOrDefault('$(CBTEnableNuGetPackageRestoreOptimization)', 'true')), $(CBTNuGetPackagesRestoredMarker), $(CBTNuGetAllProjects.Split(';')), '$(NuGetMSBuildPath)', '$(CBTNuGetRestoreAdditionalArguments)'))</CBTNuGetPackagesRestored>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(CBTNuGetPackagesRestored)' == 'true' And '$(CBTNuGetGeneratePackageProperties)' == 'true' ">
+  <PropertyGroup Condition=" '$(CBTNuGetPackagesRestored)' == 'true' And '$(CBTNuGetGeneratePackageProperties)' == 'true'  And '$(IsRestoreOnly)' != 'true'  ">
     <CBTNuGetPackagePropertiesCreated Condition=" '$(CBTNuGetTasksAssemblyName)' != '' ">$(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType('System.AppDomain').GetProperty('CurrentDomain').GetValue(null).GetData('CBT_NUGET_ASSEMBLY').CreateInstance('CBT.NuGet.Tasks.GenerateNuGetProperties').Execute($(CBTNuGetRestoreFile), $(CBTNuGetAllProjects.Split(';')), $(CBTNuGetPackagePropertyFile), $(CBTNuGetPackagePropertyVersionNamePrefix), $(CBTNuGetPackagePropertyPathNamePrefix), $(CBTNuGetAssetsFlagFile)))</CBTNuGetPackagePropertiesCreated>
   </PropertyGroup>
 
@@ -144,7 +144,7 @@
   <UsingTask AssemblyFile="$(CBTNuGetTasksAssemblyPath)" TaskName="CBT.NuGet.Tasks.GenerateNuGetProperties" />
 
   <Target Name="RestoreNuGetPackages"
-    Condition=" '$(CBTEnablePackageRestore)' == 'true' And '$(BuildingInsideVisualStudio)' != 'true' "
+    Condition=" '$(CBTEnablePackageRestore)' == 'true' And '$(CBTNuGetPackagesRestored)' != 'true' And '$(BuildingInsideVisualStudio)' != 'true' "
     DependsOnTargets="_CheckForCBTNuGetPackagesRestoredMarker;$(RestoreNuGetPackagesDependsOn)"
     Inputs="$(CBTNuGetAllProjects);$(CBTNuGetRestoreFile)"
     Outputs="$(CBTNuGetPackagesRestoredMarker)">
@@ -172,11 +172,6 @@
     <Touch AlwaysCreate="true" ForceTouch="true" Files="$(CBTNuGetPackagesRestoredMarker)" Condition=" '$(CBTEnableNuGetPackageRestoreOptimization)' != 'false' " />
 
     <CallTarget Targets="_CheckForCBTNuGetPackagesRestoredMarker" />
-
-    <PropertyGroup Condition=" '$(CBTNuGetGeneratePackageProperties)' == 'true' And '$(IsRestoreOnly)' == 'true' ">
-      <CBTNuGetPackagePropertiesCreated Condition=" '$(CBTNuGetTasksAssemblyName)' != '' ">$(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType('System.AppDomain').GetProperty('CurrentDomain').GetValue(null).GetData(`CBT_NUGET_ASSEMBLY`).CreateInstance('CBT.NuGet.Tasks.GenerateNuGetProperties').Execute($(CBTNuGetRestoreFile), $(CBTNuGetAllProjects.Split(';')), $(CBTNuGetPackagePropertyFile), $(CBTNuGetPackagePropertyVersionNamePrefix), $(CBTNuGetPackagePropertyPathNamePrefix), $(CBTNuGetAssetsFlagFile)))</CBTNuGetPackagePropertiesCreated>
-    </PropertyGroup>
-
   </Target>
 
   <Target Name="_CheckForCBTNuGetPackagesRestoredMarker">

--- a/src/CBT.NuGet.Package/build/RestoreOnly.targets
+++ b/src/CBT.NuGet.Package/build/RestoreOnly.targets
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="Restore" DependsOnTargets="$(RestoreDependsOn)" />
+
+</Project>

--- a/src/CBT.Traversal/build/Traversal.targets
+++ b/src/CBT.Traversal/build/Traversal.targets
@@ -51,7 +51,7 @@
 
   <Target Name="Rebuild" DependsOnTargets="$(RebuildDependsOn)" />
 
-  <Target Name="Restore" DependsOnTargets="$(RestoreDependsOn)" Condition=" '$(EnableProjectRestore)' != 'false' ">
+  <Target Name="Restore" DependsOnTargets="$(RestoreDependsOn)">
     <MSBuild Projects="@(PreTraversalProjectFile)" Targets="Restore" Condition=" '@(PreTraversalProjectFile)' != '' " />
 
     <MSBuild Projects="@(ProjectFile)" Targets="Restore" BuildInParallel="$(BuildInParallel)" SkipNonexistentProjects="$(SkipNonexistentProjects)" Properties="CBTModulesRestored=$(CBTModulesRestored);IsRestoreOnly=true;$(TraversalGlobalProperties);$(TraversalRestoreGlobalProperties)" />


### PR DESCRIPTION
This functionality was lost when I switched traversal restore to an SLN-based restore.  The project tree isn't built because we couldn't disable the stock Restore target.

This change can disable the stock Restore target and can run out targets for each project in the tree which in turn lets us generate NuGet package properties during traversal restore