### PR TITLE
Disable global package restore during traversal restore

### DIFF
--- a/src/CBT.NuGet.GlobalRestore/CBT.NuGet.GlobalRestore.nuproj
+++ b/src/CBT.NuGet.GlobalRestore/CBT.NuGet.GlobalRestore.nuproj
@@ -13,6 +13,7 @@
     <Dependency Include="CBT.NuGet">
       <Version>[2.0.0,)</Version>
     </Dependency>
+    <Content Include="build\After.Traversal.targets" />
     <Content Include="build\Before.CBT.NuGet.PackageProperties.props" />
     <Content Include="build\After.Microsoft.Common.targets" />
     <Content Include="build\module.config" />

--- a/src/CBT.NuGet.GlobalRestore/CBT.NuGet.GlobalRestore.nuproj
+++ b/src/CBT.NuGet.GlobalRestore/CBT.NuGet.GlobalRestore.nuproj
@@ -11,7 +11,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <ItemGroup>
     <Dependency Include="CBT.NuGet">
-      <Version>[2.0.0,)</Version>
+      <Version>[2.1.19,)</Version>
     </Dependency>
     <Content Include="build\After.Traversal.targets" />
     <Content Include="build\Before.CBT.NuGet.PackageProperties.props" />

--- a/src/CBT.NuGet.GlobalRestore/build/After.Microsoft.Common.targets
+++ b/src/CBT.NuGet.GlobalRestore/build/After.Microsoft.Common.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" InitialTargets="NuGetRestoreGlobalPackages">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" InitialTargets="RestoreGlobalNuGetPackages">
 
   <PropertyGroup>
     <RestoreNuGetPackagesDependsOn>RestoreGlobalNuGetPackages;$(RestoreNuGetPackagesDependsOn)</RestoreNuGetPackagesDependsOn>
@@ -7,15 +7,7 @@
   <UsingTask AssemblyFile="$(CBTNuGetTasksAssemblyPath)" TaskName="CBT.NuGet.Tasks.GenerateNuGetProperties" />
 
   <Target Name="RestoreGlobalNuGetPackages"
-    Condition=" '$(CBTEnableGlobalPackageRestore)' == 'true' And '$(BuildingInsideVisualStudio)' != 'true' "
-    DependsOnTargets="_CheckForCBTNuGetGlobalPackagesRestoredMarker"
-    Inputs="$(CBTNuGetAllProjects);$(CBTNuGetGlobalPackagesRestoreFile)"
-    Outputs="$(CBTNuGetGlobalPackagesRestoredMarker)">
-    <CallTarget Targets="NuGetRestoreGlobalPackages" />
-  </Target>
-  
-  <Target Name="NuGetRestoreGlobalPackages"
-    Condition=" '$(CBTNuGetGlobalPackagesRestored)' != 'true'"
+    Condition=" '$(CBTNuGetGlobalPackagesRestored)' != 'true' "
     Inputs="$(CBTNuGetAllProjects);$(CBTNuGetGlobalPackagesRestoreFile)"
     Outputs="$(CBTNuGetGlobalPackagesRestoredMarker)">
 

--- a/src/CBT.NuGet.GlobalRestore/build/After.Traversal.targets
+++ b/src/CBT.NuGet.GlobalRestore/build/After.Traversal.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TraversalGlobalProperties>$(TraversalGlobalProperties);CBTNuGetGlobalPackagesRestored=$(CBTNuGetGlobalPackagesRestored)</TraversalGlobalProperties>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Global packages are restored when parsing a dirs.proj and so we don't need every project to also do the work