### PR TITLE
Fix FrameworkPathOverride for NET 471

### DIFF
--- a/src/CBT.DotNetFx-net47/build/CBT.DotNetFx-net47.targets
+++ b/src/CBT.DotNetFx-net47/build/CBT.DotNetFx-net47.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <FrameworkPathOverride Condition=" '$(TargetFrameworkVersion)' == 'v4.7' or '$(TargetFramework)' == 'net47' ">$(MSBuildThisFileDirectory)net46\</FrameworkPathOverride>
+    <FrameworkPathOverride Condition=" '$(TargetFrameworkVersion)' == 'v4.7' or '$(TargetFramework)' == 'net47' ">$(MSBuildThisFileDirectory)net47\</FrameworkPathOverride>
   </PropertyGroup>
   <PropertyGroup Condition="'$(FrameworkPathOverride)' != ''">
     <_FullFrameworkReferenceAssemblyPaths>$(FrameworkPathOverride)</_FullFrameworkReferenceAssemblyPaths>

--- a/src/CBT.DotNetFx-net471/build/CBT.DotNetFx-net471.targets
+++ b/src/CBT.DotNetFx-net471/build/CBT.DotNetFx-net471.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <FrameworkPathOverride Condition=" '$(TargetFrameworkVersion)' == 'v4.7.1' or '$(TargetFramework)' == 'net471' ">$(MSBuildThisFileDirectory)net46\</FrameworkPathOverride>
+    <FrameworkPathOverride Condition=" '$(TargetFrameworkVersion)' == 'v4.7.1' or '$(TargetFramework)' == 'net471' ">$(MSBuildThisFileDirectory)net471\</FrameworkPathOverride>
   </PropertyGroup>
   <PropertyGroup Condition="'$(FrameworkPathOverride)' != ''">
     <_FullFrameworkReferenceAssemblyPaths>$(FrameworkPathOverride)</_FullFrameworkReferenceAssemblyPaths>


### PR DESCRIPTION
FrameworkPathOverride was incorrectly set to net46 for NET47 and NET471 CBT framework modules.