### PR TITLE
Add new base class SemaphoreTask for tasks that should only run one at a time

### DIFF
--- a/src/CBT.NuGet.UnitTests/CBT.NuGet.UnitTests.csproj
+++ b/src/CBT.NuGet.UnitTests/CBT.NuGet.UnitTests.csproj
@@ -20,6 +20,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ExtensionMethodsTests.cs" />
     <Compile Include="NuGetPathPropertiesTests.cs" />
     <Compile Include="AggregatePackageTests.cs" />
     <Compile Include="ExtensionMethods.cs" />

--- a/src/CBT.NuGet.UnitTests/ExtensionMethodsTests.cs
+++ b/src/CBT.NuGet.UnitTests/ExtensionMethodsTests.cs
@@ -10,21 +10,21 @@ namespace CBT.NuGet.UnitTests
         [InlineData("zxcvbnm,./asdfghjkl;'qwertyuiop[]\\`1234567890-=~!@#$%^&*()_+{}|:\"<>?")]
         [InlineData("ZXCVBNM,./ASDFGHJKL;'QWERTYUIOP[]\\`1234567890-=~!@#$%^&*()_+{}|:\"<>?")]
         [InlineData("Zxcvbnm,./asdfghjkl;'qwertyuiop[]\\`1234567890-=~!@#$%^&*()_+{}|:\"<>?")]
-        public void GetMD5HashCaseInsensitive(string input)
+        public void GetHashCaseInsensitive(string input)
         {
-            input.GetMd5Hash().ShouldBe("D79C4C79DD4DC91869D3DD98AA70E3F9");
+            input.GetHash().ShouldBe("RqVWg4YHc/mLuuEhWQmeClqjVrrZFDD+TK2Ubahsq/Q=");
         }
 
         [Fact]
-        public void GetMD5HashTest()
+        public void GetHashTest()
         {
-            "Hello World".GetMd5Hash().ShouldBe("361FADF1C712E812D198C4CAB5712A79");
+            "Hello World".GetHash().ShouldBe("eH7Hbcr9IMGQjrCTahL5Ht0QWrXNfswrGuIDJkg0Xf8=");
         }
 
         [Fact]
-        public void GetMD5HashTestMaxPath()
+        public void GetHashTestMaxPath()
         {
-            new string('s', 1024).GetMd5Hash().ShouldBe("3677C1915A53814950925D816AE380B2");
+            new string('s', 1024).GetHash().ShouldBe("UpoU1WutH2vtQTWhm6u11gVJLaSIf7uZHtds2shv1TU=");
         }
     }
 }

--- a/src/CBT.NuGet.UnitTests/ExtensionMethodsTests.cs
+++ b/src/CBT.NuGet.UnitTests/ExtensionMethodsTests.cs
@@ -1,0 +1,30 @@
+﻿using CBT.NuGet.Internal;
+using Shouldly;
+using Xunit;
+
+namespace CBT.NuGet.UnitTests
+{
+    public class ExtensionMethodsTests
+    {
+        [Theory]
+        [InlineData("zxcvbnm,./asdfghjkl;'qwertyuiop[]\\`1234567890-=~!@#$%^&*()_+{}|:\"<>?")]
+        [InlineData("ZXCVBNM,./ASDFGHJKL;'QWERTYUIOP[]\\`1234567890-=~!@#$%^&*()_+{}|:\"<>?")]
+        [InlineData("Zxcvbnm,./asdfghjkl;'qwertyuiop[]\\`1234567890-=~!@#$%^&*()_+{}|:\"<>?")]
+        public void GetMD5HashCaseInsensitive(string input)
+        {
+            input.GetMd5Hash().ShouldBe("D79C4C79DD4DC91869D3DD98AA70E3F9");
+        }
+
+        [Fact]
+        public void GetMD5HashTest()
+        {
+            "Hello World".GetMd5Hash().ShouldBe("361FADF1C712E812D198C4CAB5712A79");
+        }
+
+        [Fact]
+        public void GetMD5HashTestMaxPath()
+        {
+            new string('s', 1024).GetMd5Hash().ShouldBe("3677C1915A53814950925D816AE380B2");
+        }
+    }
+}

--- a/src/CBT.NuGet.UnitTests/NuGetPathPropertiesTests.cs
+++ b/src/CBT.NuGet.UnitTests/NuGetPathPropertiesTests.cs
@@ -26,8 +26,6 @@ namespace CBT.NuGet.UnitTests
             BuildEngine = new MockBuildEngine()
         });
 
-
-
         [Fact]
         public void ReadJsonFileTest()
         {
@@ -194,7 +192,9 @@ namespace CBT.NuGet.UnitTests
                 }
             };
 
-            new NuGetPropertyGenerator(_log, settings, packageConfigFile).Generate(outputFile, "NuGetVersion_", "NuGetPath_", packageRestoreData).ShouldBe(true);
+            new NuGetPropertyGenerator(_log, settings, packageConfigFile).Generate(outputFile, "NuGetVersion_", "NuGetPath_", packageRestoreData);
+
+            _log.HasLoggedErrors.ShouldBeFalse();
             File.Exists(outputFile).ShouldBe(true);
             File.ReadAllText(outputFile).NormalizeNewLine().ShouldBe(expectedOutputContent.NormalizeNewLine());
 
@@ -236,7 +236,9 @@ namespace CBT.NuGet.UnitTests
                 }
             };
 
-            new NuGetPropertyGenerator(_log, settings, projectPackageReferenceFile).Generate(outputFile, "NuGetVersion_", "NuGetPath_", packageRestoreData).ShouldBe(true);
+            new NuGetPropertyGenerator(_log, settings, projectPackageReferenceFile).Generate(outputFile, "NuGetVersion_", "NuGetPath_", packageRestoreData);
+
+            _log.HasLoggedErrors.ShouldBeFalse();
             File.Exists(outputFile).ShouldBe(true);
             File.ReadAllText(outputFile).NormalizeNewLine().ShouldBe(expectedOutputContent.NormalizeNewLine());
         }
@@ -280,7 +282,9 @@ namespace CBT.NuGet.UnitTests
                 }
             };
 
-            new NuGetPropertyGenerator(_log, settings, projectJsonFile).Generate(outputFile, "NuGetVersion_", "NuGetPath_", packageRestoreData).ShouldBe(true);
+            new NuGetPropertyGenerator(_log, settings, projectJsonFile).Generate(outputFile, "NuGetVersion_", "NuGetPath_", packageRestoreData);
+
+            _log.HasLoggedErrors.ShouldBeFalse();
             File.Exists(outputFile).ShouldBe(true);
             File.ReadAllText(outputFile).NormalizeNewLine().ShouldBe(expectedOutputContent.NormalizeNewLine());
         }

--- a/src/CBT.NuGet/CBT.NuGet.csproj
+++ b/src/CBT.NuGet/CBT.NuGet.csproj
@@ -36,6 +36,7 @@
     <Compile Include="Internal\PackageIdentityWithPath.cs" />
     <Compile Include="Internal\PackageInfo.cs" />
     <Compile Include="Internal\PackageRestoreData.cs" />
+    <Compile Include="Internal\SemaphoreTask.cs" />
     <Compile Include="Tasks\AggregatePackages.cs" />
     <Compile Include="Tasks\GenerateNuGetProperties.cs" />
     <Compile Include="Tasks\ImportBuildPackages.cs" />

--- a/src/CBT.NuGet/Internal/ExtensionMethods.cs
+++ b/src/CBT.NuGet/Internal/ExtensionMethods.cs
@@ -9,6 +9,8 @@ namespace CBT.NuGet.Internal
 {
     internal static class ExtensionMethods
     {
+        private static Lazy<SHA256> _hasherLazy = new Lazy<SHA256>(SHA256.Create, isThreadSafe: true);
+
         public static void AppendSwitchIfAny(this CommandLineBuilder commandLineBuilder, string switchName, IEnumerable<ITaskItem> items)
         {
             if (items != null)
@@ -39,16 +41,15 @@ namespace CBT.NuGet.Internal
         /// <summary>
         /// Gets a case-insensitive MD5 hash of the current string.
         /// </summary>
-        public static string GetMd5Hash(this string input)
+        public static string GetHash(this string input, string prefix = null)
         {
-            using (MD5 md5 = MD5.Create())
+            if (prefix != null)
             {
-                StringBuilder sb = new StringBuilder();
-                foreach (byte hashByte in md5.ComputeHash(Encoding.UTF8.GetBytes(input.ToUpperInvariant())))
-                {
-                    sb.Append(hashByte.ToString("X2"));
-                }
-                return sb.ToString();
+                return $"{prefix}{Convert.ToBase64String(_hasherLazy.Value.ComputeHash(Encoding.UTF8.GetBytes(input.ToUpperInvariant())))}";
+            }
+            else
+            {
+                return Convert.ToBase64String(_hasherLazy.Value.ComputeHash(Encoding.UTF8.GetBytes(input.ToUpperInvariant())));
             }
         }
     }

--- a/src/CBT.NuGet/Internal/ExtensionMethods.cs
+++ b/src/CBT.NuGet/Internal/ExtensionMethods.cs
@@ -1,7 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.Build.Framework;
+﻿using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace CBT.NuGet.Internal
 {
@@ -31,6 +33,22 @@ namespace CBT.NuGet.Internal
             if (value)
             {
                 commandLineBuilder.AppendSwitch(switchName);
+            }
+        }
+
+        /// <summary>
+        /// Gets a case-insensitive MD5 hash of the current string.
+        /// </summary>
+        public static string GetMd5Hash(this string input)
+        {
+            using (MD5 md5 = MD5.Create())
+            {
+                StringBuilder sb = new StringBuilder();
+                foreach (byte hashByte in md5.ComputeHash(Encoding.UTF8.GetBytes(input.ToUpperInvariant())))
+                {
+                    sb.Append(hashByte.ToString("X2"));
+                }
+                return sb.ToString();
             }
         }
     }

--- a/src/CBT.NuGet/Internal/FileUtilities.cs
+++ b/src/CBT.NuGet/Internal/FileUtilities.cs
@@ -1,12 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace CBT.NuGet.Internal
 {
@@ -67,17 +62,6 @@ namespace CBT.NuGet.Internal
                     string temppath = Path.Combine(destDirName, subdir.Name);
                     DirectoryRemove(subdir.FullName, temppath, recurseSubDirs);
                 }
-            }
-        }
-
-        // Mutex isn't platform agnostic need to consider options.
-        public static string ComputeMutexName(string sessionString)
-        {
-            // get a hash of the file path; reason: there's a limit on name length for named mutexes
-            using (var algo = SHA256.Create())
-            {
-                // Global: make it work across TS sessions; not that we should need this, but just to be super-extra safe
-                return "Global\\" + Convert.ToBase64String(algo.ComputeHash(Encoding.UTF8.GetBytes(sessionString.ToUpperInvariant())));
             }
         }
 

--- a/src/CBT.NuGet/Internal/NuGetPropertyGenerator.cs
+++ b/src/CBT.NuGet/Internal/NuGetPropertyGenerator.cs
@@ -42,7 +42,7 @@ namespace CBT.NuGet.Internal
             });
         }
 
-        public bool Generate(string outputPath, string propertyVersionNamePrefix, string propertyPathNamePrefix, PackageRestoreData restoreData)
+        public void Generate(string outputPath, string propertyVersionNamePrefix, string propertyPathNamePrefix, PackageRestoreData restoreData)
         {
             // Delete an existing file in case there are no properties generated and we don't end up saving the file
             //
@@ -93,8 +93,6 @@ namespace CBT.NuGet.Internal
             {
                 Retry(() => project.Save(outputPath), TimeSpan.FromMilliseconds(500));
             }
-
-            return true;
         }
 
         private static void Retry(Action action, TimeSpan retryInterval, int retryCount = 3)

--- a/src/CBT.NuGet/Internal/SemaphoreTask.cs
+++ b/src/CBT.NuGet/Internal/SemaphoreTask.cs
@@ -24,7 +24,7 @@ namespace CBT.NuGet.Internal
                 return !Log.HasLoggedErrors;
             }
 
-            using (Semaphore semaphore = new Semaphore(0, 1, SemaphoreName.GetMd5Hash(), out bool releaseSemaphore))
+            using (Semaphore semaphore = new Semaphore(0, 1, SemaphoreName.GetHash(), out bool releaseSemaphore))
             {
                 try
                 {

--- a/src/CBT.NuGet/Internal/SemaphoreTask.cs
+++ b/src/CBT.NuGet/Internal/SemaphoreTask.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.Build.Utilities;
+using System;
+using System.Threading;
+
+namespace CBT.NuGet.Internal
+{
+    public abstract class SemaphoreTask : Task
+    {
+        /// <summary>
+        /// Gets or sets a value indicating if the task should only run once.  The default is <code>true</code>.
+        /// Set this to <code>false</code> to have the task run multiple times but only have on thread running at one time.
+        /// </summary>
+        protected virtual bool RunOnceOnly { get; } = true;
+
+        protected abstract string SemaphoreName { get; }
+
+        protected virtual TimeSpan SemaphoreTimeout { get; } = TimeSpan.FromMinutes(30);
+
+        public override bool Execute()
+        {
+            using (Semaphore semaphore = new Semaphore(0, 1, SemaphoreName.GetMd5Hash(), out bool releaseSemaphore))
+            {
+                try
+                {
+                    if (!releaseSemaphore)
+                    {
+                        releaseSemaphore = semaphore.WaitOne(SemaphoreTimeout);
+
+                        if (RunOnceOnly)
+                        {
+                            return releaseSemaphore;
+                        }
+                    }
+
+                    Run();
+                }
+                finally
+                {
+                    if (releaseSemaphore)
+                    {
+                        semaphore.Release();
+                    }
+                }
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        public abstract void Run();
+    }
+}

--- a/src/CBT.NuGet/Tasks/AggregatePackages.cs
+++ b/src/CBT.NuGet/Tasks/AggregatePackages.cs
@@ -112,7 +112,7 @@ namespace CBT.NuGet.Tasks
                 return true;
             }
 
-            using (var mutex = new Mutex(false, FileUtilities.ComputeMutexName(package.OutPropertyValue)))
+            using (var mutex = new Mutex(false, package.OutPropertyValue.GetHash(prefix: @"Global\")))
             {
                 bool owner = false;
                 try

--- a/src/CBT.NuGet/Tasks/AggregatePackages.cs
+++ b/src/CBT.NuGet/Tasks/AggregatePackages.cs
@@ -1,7 +1,6 @@
 ﻿using CBT.NuGet.Internal;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -16,8 +15,20 @@ namespace CBT.NuGet.Tasks
     ///
     /// Generate properties that contain the path and version of a given nuget package.
     /// </summary>
-    public sealed class AggregatePackages : Task
+    public sealed class AggregatePackages : SemaphoreTask
     {
+        /// <summary>
+        /// Gets or sets the root path of the packages to be aggregated.
+        /// </summary>
+        [Required]
+        public string AggregateDestRoot { get; set; }
+
+        /// <summary>
+        /// Gets or sets the root paths of folders that are considered to be immutable and that the content will never change for that unique folder name.  Example a nuget package.
+        /// </summary>
+        [Required]
+        public string ImmutableRoots { get; set; }
+
         /// <summary>
         /// Gets or sets the msbuild item of that contains the packages to aggregate.
         /// Example Input:
@@ -37,81 +48,7 @@ namespace CBT.NuGet.Tasks
         [Required]
         public string PropsFile { get; set; }
 
-        /// <summary>
-        /// Gets or sets the root path of the packages to be aggregated.
-        /// </summary>
-        [Required]
-        public string AggregateDestRoot { get; set; }
-
-        /// <summary>
-        /// Gets or sets the root paths of folders that are considered to be immutable and that the content will never change for that unique folder name.  Example a nuget package.
-        /// </summary>
-        [Required]
-        public string ImmutableRoots { get; set; }
-
-        public override bool Execute()
-        {
-            string semaphoreName = PropsFile.ToUpper().GetHashCode().ToString("X");
-
-            using (Semaphore semaphore = new Semaphore(0, 1, semaphoreName, out bool releaseSemaphore))
-            {
-                try
-                {
-                    if (!releaseSemaphore)
-                    {
-                        releaseSemaphore = semaphore.WaitOne(TimeSpan.FromMinutes(30));
-
-                        return releaseSemaphore;
-                    }
-
-                    IDictionary<string, string> propertiesToCreate = new Dictionary<string, string>();
-
-                    foreach (var pkg in ParsePackagesToAggregate())
-                    {
-                        try
-                        {
-                            if (!CreateAggregatePackage(pkg))
-                            {
-                                Log.LogError("Failed to create aggregate package {0} for input of {1}", pkg.OutPropertyId, PackagesToAggregate);
-                            }
-                        }
-                        catch (DirectoryNotFoundException)
-                        {
-                            Log.LogError("Aggregate package {0} not found after aggregation.", pkg.OutPropertyValue);
-                        }
-                        if (propertiesToCreate.ContainsKey(pkg.OutPropertyId))
-                        {
-                            Log.LogWarning("Duplicate Aggregate package {0} specified.  Using first defined.", pkg.OutPropertyId);
-                            continue;
-                        }
-                        propertiesToCreate.Add(pkg.OutPropertyId, pkg.OutPropertyValue);
-                    }
-
-                    try
-                    {
-                        CreatePropsFile(propertiesToCreate, PropsFile);
-                    }
-                    catch (Exception e)
-                    {
-                        Log.LogErrorFromException(e);
-                    }
-
-                    if (Log.HasLoggedErrors)
-                    {
-                        Log.LogError("Define aggregate packages in the format of 'MYAGGPROPERTY=c:\\pkg1|c:\\pkg2|!c:\\pkg3;MYAAGPROPERTY2=c:\\pkg1|c:\\pkg2' where ; seperates aggregate packages and | seperates paths to be aggregated for a package and ! denotes content that should be excluded from the aggregate.");
-                    }
-
-                    return !Log.HasLoggedErrors;
-                }
-                finally
-                {
-                    if (releaseSemaphore)
-                    {
-                        semaphore.Release();
-                    }
-                }
-            }
-        }
+        protected override string SemaphoreName => PropsFile;
 
         public bool Execute(string aggregateDestRoot, string packagesToAggregate, string propsFile, string immutableRoots)
         {
@@ -123,73 +60,45 @@ namespace CBT.NuGet.Tasks
             return Execute();
         }
 
-        internal void CreatePropsFile(IDictionary<string, string> propertyPairs, string propsFile)
+        public override void Run()
         {
-            ProjectRootElement project = ProjectRootElement.Create();
+            IDictionary<string, string> propertiesToCreate = new Dictionary<string, string>();
 
-            ProjectPropertyGroupElement propertyGroup = project.AddPropertyGroup();
-            propertyGroup.SetProperty("MSBuildAllProjects", "$(MSBuildAllProjects);$(MSBuildThisFileFullPath)");
-
-            foreach (var kvp in propertyPairs)
+            foreach (var pkg in ParsePackagesToAggregate())
             {
-                propertyGroup.SetProperty(kvp.Key, kvp.Value);
-            }
-
-            project.Save(propsFile);
-        }
-
-        internal IEnumerable<AggregatePackage> ParsePackagesToAggregate()
-        {
-            // foo=pkg|pkg2|!pkg3;foo2=pkg|pkg2|!pkg3
-
-            foreach (var item in PackagesToAggregate.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
-                                                   .Select(i => i.Trim())
-                                                   .Where(i => !String.IsNullOrWhiteSpace(i))
-                                                   .Select(i => i.Split(new[] { '=' }, 2, StringSplitOptions.RemoveEmptyEntries))
-                                                   .Select(i => new
-                                                   {
-                                                       PropertyName = i.First(),
-                                                       Options = i.Length == 2 ? i.Last() : null
-                                                   })
-            )
-            {
-                IList<PackageOperation> packageOperations = ParsePackageOperations(item.Options).ToList();
-
-                if (packageOperations.Count == 0)
+                try
                 {
-                    // Invalid item because nothing is on the right side of the equal sign or there was no equal sign
-                    Log.LogError($"No valid paths were found to aggregate for '{item.PropertyName}' with options '{item.Options}'");
+                    if (!CreateAggregatePackage(pkg))
+                    {
+                        Log.LogError("Failed to create aggregate package {0} for input of {1}", pkg.OutPropertyId, PackagesToAggregate);
+                    }
+                }
+                catch (DirectoryNotFoundException)
+                {
+                    Log.LogError("Aggregate package {0} not found after aggregation.", pkg.OutPropertyValue);
+                }
+
+                if (propertiesToCreate.ContainsKey(pkg.OutPropertyId))
+                {
+                    Log.LogWarning("Duplicate Aggregate package {0} specified.  Using first defined.", pkg.OutPropertyId);
                     continue;
                 }
 
-                yield return new AggregatePackage(item.PropertyName, packageOperations, AggregateDestRoot, ImmutableRoots);
-            }
-        }
-
-        private IEnumerable<PackageOperation> ParsePackageOperations(string options)
-        {
-            // pkg1|pkg2|!pkg
-
-            if (String.IsNullOrWhiteSpace(options))
-            {
-                yield break;
+                propertiesToCreate.Add(pkg.OutPropertyId, pkg.OutPropertyValue);
             }
 
-            foreach (var option in options.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries)
-                                                   .Select(i => i.Trim())
-                                                   .Where(i => !String.IsNullOrWhiteSpace(i)))
+            try
             {
-                AggregateOperation aggregateOperation = option.First() == (char)AggregateOperation.Remove ? AggregateOperation.Remove : AggregateOperation.Add;
+                CreatePropsFile(propertiesToCreate, PropsFile);
+            }
+            catch (Exception e)
+            {
+                Log.LogErrorFromException(e);
+            }
 
-                string folder = option.TrimStart((char)AggregateOperation.Remove).Trim();
-
-                if (!Directory.Exists(folder))
-                {
-                    Log.LogError($"Path to aggregate '{folder}' does not exist.");
-                    continue;
-                }
-
-                yield return new PackageOperation { Operation = aggregateOperation, Folder = folder };
+            if (Log.HasLoggedErrors)
+            {
+                Log.LogError("Define aggregate packages in the format of 'MYAGGPROPERTY=c:\\pkg1|c:\\pkg2|!c:\\pkg3;MYAAGPROPERTY2=c:\\pkg1|c:\\pkg2' where ; seperates aggregate packages and | seperates paths to be aggregated for a package and ! denotes content that should be excluded from the aggregate.");
             }
         }
 
@@ -223,6 +132,7 @@ namespace CBT.NuGet.Tasks
                         Log.LogMessage(MessageImportance.Low, $"{outTmpDir} not cleaned up from previous build cleaning now.");
                         Directory.Delete(outTmpDir, true);
                     }
+
                     foreach (var srcPkg in package.PackagesToAggregate)
                     {
                         if (srcPkg.Operation.Equals(AggregatePackage.AggregateOperation.Add))
@@ -230,12 +140,14 @@ namespace CBT.NuGet.Tasks
                             Log.LogMessage(MessageImportance.Low, $"Adding {srcPkg.Folder} to aggregate of {package.OutPropertyValue}");
                             FileUtilities.DirectoryCopy(srcPkg.Folder, outTmpDir, true, true);
                         }
+
                         if (srcPkg.Operation.Equals(AggregatePackage.AggregateOperation.Remove))
                         {
                             Log.LogMessage(MessageImportance.Low, $"Removing {srcPkg.Folder} from aggregate of {package.OutPropertyValue}");
                             FileUtilities.DirectoryRemove(srcPkg.Folder, outTmpDir, true);
                         }
                     }
+
                     Directory.Move(outTmpDir, package.OutPropertyValue);
                 }
                 finally
@@ -246,8 +158,78 @@ namespace CBT.NuGet.Tasks
                     }
                 }
             }
+
             return Directory.Exists(package.OutPropertyValue);
         }
 
+        internal void CreatePropsFile(IDictionary<string, string> propertyPairs, string propsFile)
+        {
+            ProjectRootElement project = ProjectRootElement.Create();
+
+            ProjectPropertyGroupElement propertyGroup = project.AddPropertyGroup();
+            propertyGroup.SetProperty("MSBuildAllProjects", "$(MSBuildAllProjects);$(MSBuildThisFileFullPath)");
+
+            foreach (var kvp in propertyPairs)
+            {
+                propertyGroup.SetProperty(kvp.Key, kvp.Value);
+            }
+
+            project.Save(propsFile);
+        }
+
+        internal IEnumerable<AggregatePackage> ParsePackagesToAggregate()
+        {
+            // foo=pkg|pkg2|!pkg3;foo2=pkg|pkg2|!pkg3
+
+            foreach (var item in PackagesToAggregate.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries)
+                .Select(i => i.Trim())
+                .Where(i => !String.IsNullOrWhiteSpace(i))
+                .Select(i => i.Split(new[] {'='}, 2, StringSplitOptions.RemoveEmptyEntries))
+                .Select(i => new
+                {
+                    PropertyName = i.First(),
+                    Options = i.Length == 2 ? i.Last() : null
+                })
+            )
+            {
+                IList<PackageOperation> packageOperations = ParsePackageOperations(item.Options).ToList();
+
+                if (packageOperations.Count == 0)
+                {
+                    // Invalid item because nothing is on the right side of the equal sign or there was no equal sign
+                    Log.LogError($"No valid paths were found to aggregate for '{item.PropertyName}' with options '{item.Options}'");
+                    continue;
+                }
+
+                yield return new AggregatePackage(item.PropertyName, packageOperations, AggregateDestRoot, ImmutableRoots);
+            }
+        }
+
+        private IEnumerable<PackageOperation> ParsePackageOperations(string options)
+        {
+            // pkg1|pkg2|!pkg
+
+            if (String.IsNullOrWhiteSpace(options))
+            {
+                yield break;
+            }
+
+            foreach (var option in options.Split(new[] {'|'}, StringSplitOptions.RemoveEmptyEntries)
+                .Select(i => i.Trim())
+                .Where(i => !String.IsNullOrWhiteSpace(i)))
+            {
+                AggregateOperation aggregateOperation = option.First() == (char) AggregateOperation.Remove ? AggregateOperation.Remove : AggregateOperation.Add;
+
+                string folder = option.TrimStart((char) AggregateOperation.Remove).Trim();
+
+                if (!Directory.Exists(folder))
+                {
+                    Log.LogError($"Path to aggregate '{folder}' does not exist.");
+                    continue;
+                }
+
+                yield return new PackageOperation {Operation = aggregateOperation, Folder = folder};
+            }
+        }
     }
 }

--- a/src/CBT.NuGet/Tasks/NuGetRestore.cs
+++ b/src/CBT.NuGet/Tasks/NuGetRestore.cs
@@ -105,9 +105,7 @@ namespace CBT.NuGet.Tasks
 
             // Do restoration in a semaphore to prevent NuGet restore having locking issues
             //
-            string semaphoreName = File.ToUpper().GetHashCode().ToString("X");
-
-            using (Semaphore semaphore = new Semaphore(0, 1, semaphoreName, out bool releaseSemaphore))
+            using (Semaphore semaphore = new Semaphore(0, 1, File.GetHash(), out bool releaseSemaphore))
             {
                 try
                 {
@@ -253,9 +251,7 @@ namespace CBT.NuGet.Tasks
 
         protected void GenerateNuGetOptimizationFile(string markerPath)
         {
-            string semaphoreName = markerPath.ToUpper().GetHashCode().ToString("X");
-
-            using (Semaphore semaphore = new Semaphore(0, 1, semaphoreName, out bool releaseSemaphore))
+            using (Semaphore semaphore = new Semaphore(0, 1, markerPath.GetHash(), out bool releaseSemaphore))
             {
                 try
                 {


### PR DESCRIPTION
Some tasks are using semaphore so this just makes a handy base class.

Instead of using `GetHashCode()` for the semaphore name, use an MD5 hash.  `GetHashCode()` won't return the same value for x86 and x64.  It also ensures that the semaphore name stays under the 260 character limit.

Updated `AggregatePackage`, `GenerateNuGetProperties`, and `WriteNuGetRestoreInfo` tasks to use the new `SemaphoreTask` base class.