### PR TITLE
Write out CBTNuGetTraversalPackagesRestoredMarker during traversal restore

### DIFF
--- a/src/CBT.NuGet/Tasks/TraversalNuGetRestore.cs
+++ b/src/CBT.NuGet/Tasks/TraversalNuGetRestore.cs
@@ -73,6 +73,13 @@ namespace CBT.NuGet.Tasks
                     {
                         GenerateNuGetOptimizationFile(restoreMarkerPath);
                     }
+
+                    restoreMarkerPath = loadedProject.GetPropertyValue("CBTNuGetTraversalPackagesRestoredMarker");
+
+                    if (!String.IsNullOrWhiteSpace(restoreMarkerPath))
+                    {
+                        GenerateNuGetOptimizationFile(restoreMarkerPath);
+                    }
                 }
             }
 


### PR DESCRIPTION
Subsequent parsing of projects doesn't store state that projects have already been restored.