### PR TITLE
Fix up-to-date check in ImportBuildPackages

### DIFF
--- a/src/CBT.NuGet.UnitTests/CBT.NuGet.UnitTests.csproj
+++ b/src/CBT.NuGet.UnitTests/CBT.NuGet.UnitTests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ExtensionMethodsTests.cs" />
+    <Compile Include="ImportBuildPackagesTests.cs" />
     <Compile Include="NuGetPathPropertiesTests.cs" />
     <Compile Include="AggregatePackageTests.cs" />
     <Compile Include="ExtensionMethods.cs" />

--- a/src/CBT.NuGet.UnitTests/ImportBuildPackagesTests.cs
+++ b/src/CBT.NuGet.UnitTests/ImportBuildPackagesTests.cs
@@ -1,0 +1,73 @@
+﻿using CBT.NuGet.Tasks;
+using CBT.UnitTests.Common;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace CBT.NuGet.UnitTests
+{
+    public class ImportBuildPackagesTests : TestBase
+    {
+        [Fact]
+        public void Test()
+        {
+            MockBuildEngine buildEngine = new MockBuildEngine();
+
+            string[] modulePaths =
+            {
+                CreateDirectory("NotABuildPackage", new Dictionary<string, string>
+                {
+                    { "foo.props", String.Empty }
+                }),
+                CreateDirectory("Module.One", new Dictionary<string, string>
+                {
+                    { @"build\module.config", String.Empty },
+                    { @"build\Module.One.props", String.Empty },
+                    { @"build\Module.One.targets", String.Empty },
+                }),
+                CreateDirectory("BuildPackage.One", new Dictionary<string, string>
+                {
+                    { @"build\BuildPackage.One.props", String.Empty },
+                    { @"build\BuildPackage.One.targets", String.Empty },
+                })
+            };
+
+            string propsFile = Path.Combine(TestRootPath, "NuGetBuildPackages.props");
+            string targetsFile = Path.Combine(TestRootPath, "NuGetBuildPackages.targets");
+
+            ImportBuildPackages importBuildPackages = new ImportBuildPackages
+            {
+                BuildEngine = buildEngine,
+                PropsFile = propsFile,
+                TargetsFile = targetsFile,
+                ModulePaths = modulePaths.Select(i => $"{new DirectoryInfo(i).Name}={i}").ToArray()
+            };
+
+            importBuildPackages.Run();
+
+            File.Exists(propsFile).ShouldBeTrue();
+            File.Exists(targetsFile).ShouldBeTrue();
+
+            File.ReadAllText(propsFile).ShouldBe(
+                $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project ToolsVersion=""4.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <EnableBuildPackage_One Condition="" '$(EnableBuildPackage_One)' == '' "">false</EnableBuildPackage_One>
+    <RunBuildPackage_One Condition="" '$(RunBuildPackage_One)' == '' "">true</RunBuildPackage_One>
+  </PropertyGroup>
+  <Import Project=""{modulePaths[2]}\build\BuildPackage.One.props"" Condition="" '$(EnableBuildPackage_One)' == 'true' And '$(RunBuildPackage_One)' == 'true' "" />
+</Project>",
+                StringCompareShould.IgnoreLineEndings);
+
+            File.ReadAllText(targetsFile).ShouldBe(
+                $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project ToolsVersion=""4.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <Import Project=""{modulePaths[2]}\build\BuildPackage.One.targets"" Condition="" '$(EnableBuildPackage_One)' == 'true' And '$(RunBuildPackage_One)' == 'true' "" />
+</Project>",
+                StringCompareShould.IgnoreLineEndings);
+        }
+    }
+}

--- a/src/CBT.NuGet/Tasks/ImportBuildPackages.cs
+++ b/src/CBT.NuGet/Tasks/ImportBuildPackages.cs
@@ -78,6 +78,12 @@ namespace CBT.NuGet.Tasks
 
             foreach (BuildPackageInfo buildPackageInfo in ModulePaths.Select(BuildPackageInfo.FromModulePath).Where(i => i != null))
             {
+                if (buildPackageInfo.PropsPath == null && buildPackageInfo.TargetsPath == null)
+                {
+                    Log.LogMessage(MessageImportance.Low, $"  Skipping '{buildPackageInfo.Id}' because it is not a standard NuGet build package.");
+                    continue;
+                }
+
                 // If this is a cbt module do not auto import props or targets.
                 if (File.Exists(Path.Combine(Path.GetDirectoryName(buildPackageInfo.PropsPath), "module.config")))
                 {
@@ -141,19 +147,14 @@ namespace CBT.NuGet.Tasks
                 string id = parts[0];
                 string path = parts[1];
 
-                string propsPath = Path.Combine(path, "build", $"{id}.props");
-                string targetsPath = Path.Combine(path, "build", $"{id}.targets");
-
-                if (!File.Exists(propsPath) && !File.Exists(targetsPath))
-                {
-                    return null;
-                }
+                FileInfo propsFile = new FileInfo(Path.Combine(path, "build", $"{id}.props"));
+                FileInfo targetsFile = new FileInfo(Path.Combine(path, "build", $"{id}.targets"));
 
                 BuildPackageInfo buildPackageInfo = new BuildPackageInfo
                 {
                     Id = parts[0],
-                    PropsPath = propsPath,
-                    TargetsPath = targetsPath,
+                    PropsPath = propsFile.Exists ? propsFile.FullName : null,
+                    TargetsPath = targetsFile.Exists ? targetsFile.FullName : null,
                     EnablePropertyName = $"Enable{id.Replace(".", "_")}",
                     RunPropertyName = $"Run{id.Replace(".", "_")}",
                 };

--- a/src/CBT.UnitTests.Common/TestBase.cs
+++ b/src/CBT.UnitTests.Common/TestBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace CBT.UnitTests.Common
@@ -14,6 +15,25 @@ namespace CBT.UnitTests.Common
                 Directory.CreateDirectory(_testRootPath);
                 return _testRootPath;
             }
+        }
+
+        public string CreateDirectory(string name, IDictionary<string, string> files = null)
+        {
+            DirectoryInfo directory = Directory.CreateDirectory(Path.Combine(TestRootPath, name));
+
+            if (files != null)
+            {
+                foreach (KeyValuePair<string, string> file in files)
+                {
+                    FileInfo fileInfo = new FileInfo(Path.Combine(directory.FullName, file.Key));
+
+                    fileInfo.Directory.Create();
+
+                    File.WriteAllText(fileInfo.FullName, file.Value);
+                }
+            }
+
+            return directory.FullName;
         }
 
         public void Dispose()


### PR DESCRIPTION
* Reuse NuGetRetore.IsUpToDate() because it has more logging
* Remove BeforeRun logic because it was only looking at file existence and was redundant anyway
* Added a lot more logging so its easier to diagnose

Fixes #233