### PR TITLE
Fix NullReferenceException in ImportBuildPackages

### DIFF
--- a/src/CBT.NuGet.UnitTests/ImportBuildPackagesTests.cs
+++ b/src/CBT.NuGet.UnitTests/ImportBuildPackagesTests.cs
@@ -32,6 +32,14 @@ namespace CBT.NuGet.UnitTests
                 {
                     { @"build\BuildPackage.One.props", String.Empty },
                     { @"build\BuildPackage.One.targets", String.Empty },
+                }),
+                CreateDirectory("BuildPackage.Two", new Dictionary<string, string>
+                {
+                    { @"build\BuildPackage.Two.props", String.Empty },
+                }),
+                CreateDirectory("BuildPackage.Three", new Dictionary<string, string>
+                {
+                    { @"build\BuildPackage.Three.targets", String.Empty },
                 })
             };
 
@@ -57,8 +65,13 @@ namespace CBT.NuGet.UnitTests
   <PropertyGroup>
     <EnableBuildPackage_One Condition="" '$(EnableBuildPackage_One)' == '' "">false</EnableBuildPackage_One>
     <RunBuildPackage_One Condition="" '$(RunBuildPackage_One)' == '' "">true</RunBuildPackage_One>
+    <EnableBuildPackage_Two Condition="" '$(EnableBuildPackage_Two)' == '' "">false</EnableBuildPackage_Two>
+    <RunBuildPackage_Two Condition="" '$(RunBuildPackage_Two)' == '' "">true</RunBuildPackage_Two>
+    <EnableBuildPackage_Three Condition="" '$(EnableBuildPackage_Three)' == '' "">false</EnableBuildPackage_Three>
+    <RunBuildPackage_Three Condition="" '$(RunBuildPackage_Three)' == '' "">true</RunBuildPackage_Three>
   </PropertyGroup>
   <Import Project=""{modulePaths[2]}\build\BuildPackage.One.props"" Condition="" '$(EnableBuildPackage_One)' == 'true' And '$(RunBuildPackage_One)' == 'true' "" />
+  <Import Project=""{modulePaths[3]}\build\BuildPackage.Two.props"" Condition="" '$(EnableBuildPackage_Two)' == 'true' And '$(RunBuildPackage_Two)' == 'true' "" />
 </Project>",
                 StringCompareShould.IgnoreLineEndings);
 
@@ -66,6 +79,7 @@ namespace CBT.NuGet.UnitTests
                 $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <Project ToolsVersion=""4.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
   <Import Project=""{modulePaths[2]}\build\BuildPackage.One.targets"" Condition="" '$(EnableBuildPackage_One)' == 'true' And '$(RunBuildPackage_One)' == 'true' "" />
+  <Import Project=""{modulePaths[4]}\build\BuildPackage.Three.targets"" Condition="" '$(EnableBuildPackage_Three)' == 'true' And '$(RunBuildPackage_Three)' == 'true' "" />
 </Project>",
                 StringCompareShould.IgnoreLineEndings);
         }

--- a/src/CBT.NuGet/Tasks/ImportBuildPackages.cs
+++ b/src/CBT.NuGet/Tasks/ImportBuildPackages.cs
@@ -85,7 +85,7 @@ namespace CBT.NuGet.Tasks
                 }
 
                 // If this is a cbt module do not auto import props or targets.
-                if (File.Exists(Path.Combine(Path.GetDirectoryName(buildPackageInfo.PropsPath), "module.config")))
+                if (File.Exists(Path.Combine(Path.GetDirectoryName(buildPackageInfo.PropsPath ?? buildPackageInfo.TargetsPath), "module.config")))
                 {
                     Log.LogMessage(MessageImportance.Low, $"  Skipping '{buildPackageInfo.Id}' because it is a CBT Module.");
                     continue;


### PR DESCRIPTION
If a build package has just a .props or just a .targets file, then the code could throw

Updated unit test as well.