### PR TITLE
 Do not throw exception if project.assets.json does not exist

### DIFF
--- a/src/CBT.NuGet/Internal/NuGetPackageReferenceProjectParser.cs
+++ b/src/CBT.NuGet/Internal/NuGetPackageReferenceProjectParser.cs
@@ -47,10 +47,10 @@ namespace CBT.NuGet.Internal
             }
 
             string lockFilePath = Path.Combine(packageRestoreData.RestoreOutputAbsolutePath, LockFileFormat.AssetsFileName);
-
             if (!File.Exists(lockFilePath))
             {
-                throw new FileNotFoundException($"Missing expected NuGet assets file '{lockFilePath}'.  If you are redefining BaseIntermediateOutputPath ensure it is unique per project. ");
+                Log.LogError(string.Format("Missing expected NuGet assets file '{0}'.  If you are redefining BaseIntermediateOutputPath ensure it is unique per project. ", lockFilePath));
+                return false;
             }
 
             HashSet<string> processedPackages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/src/CBT.NuGet/build/CBT.NuGet.props
+++ b/src/CBT.NuGet/build/CBT.NuGet.props
@@ -28,8 +28,7 @@
     <CBTEnableImportBuildPackages Condition=" '$(CBTEnableImportBuildPackages)' == '' ">true</CBTEnableImportBuildPackages>
     <CBTNuGetIntermediateOutputPath Condition=" '$(CBTNuGetIntermediateOutputPath)' == '' And '$(IntermediateOutputPath)' != '' ">$(IntermediateOutputPath)</CBTNuGetIntermediateOutputPath>
     <CBTNuGetIntermediateOutputPath Condition=" '$(CBTNuGetIntermediateOutputPath)' == '' And '$(IntermediateOutputPath)' == '' ">$(CBTIntermediateOutputPath)\$(MSBuildProjectDirectory.ToLower().Length.ToString())</CBTNuGetIntermediateOutputPath>
-    <CBTNuGetIntermediateOutputPath Condition=" '$(TargetFramework)' != '' ">$(CBTNuGetIntermediateOutputPath)\$(TargetFramework)</CBTNuGetIntermediateOutputPath>
-    <CBTNuGetAssetsFlagFile Condition=" '$(CBTNuGetAssetsFlagFile)' == '' ">$(CBTNuGetIntermediateOutputPath)\$(MSBuildProjectFile).flag</CBTNuGetAssetsFlagFile>
+    <CBTNuGetAssetsFlagFile Condition=" '$(CBTNuGetAssetsFlagFile)' == '' ">$(CBTNuGetIntermediateOutputPath)\$(TargetFramework)$(MSBuildProjectFile).flag</CBTNuGetAssetsFlagFile>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(CBTNuGetRestoreFile)' == '' And Exists('$(MSBuildProjectDirectory)\project.json') ">
@@ -61,7 +60,7 @@
     <CBTNuGetNoCache Condition=" '$(CBTNuGetNoCache)' == '' ">false</CBTNuGetNoCache>
     <CBTNuGetNonInteractive Condition=" '$(CBTNuGetNonInteractive)' == '' ">true</CBTNuGetNonInteractive>
     <CBTNuGetTimeout Condition=" '$(CBTNuGetTimeout)' == '' ">0</CBTNuGetTimeout>
-    <CBTNuGetPackagePropertyFile Condition=" '$(CBTNuGetPackagePropertyFile)' == '' ">$(CBTNuGetIntermediateOutputPath)\$([System.IO.Path]::GetFileName('$(CBTNuGetRestoreFile)')).props</CBTNuGetPackagePropertyFile>
+    <CBTNuGetPackagePropertyFile Condition=" '$(CBTNuGetPackagePropertyFile)' == '' ">$(CBTNuGetIntermediateOutputPath)\$(TargetFramework)$([System.IO.Path]::GetFileName('$(CBTNuGetRestoreFile)')).props</CBTNuGetPackagePropertyFile>
     <CBTNuGetPackagePropertyVersionNamePrefix Condition=" '$(CBTNuGetPackagePropertyVersionNamePrefix)' == '' ">NuGetVersion_</CBTNuGetPackagePropertyVersionNamePrefix>
     <CBTNuGetPackagePropertyPathNamePrefix Condition=" '$(CBTNuGetPackagePropertyPathNamePrefix)' == '' ">NuGetPath_</CBTNuGetPackagePropertyPathNamePrefix>
     <NuGetMSBuildPath Condition=" '$(NuGetMSBuildPath)' == '' ">$(MSBuildBinPath)</NuGetMSBuildPath>

--- a/src/CBT.NuGet/build/CBT.NuGet.props
+++ b/src/CBT.NuGet/build/CBT.NuGet.props
@@ -28,6 +28,7 @@
     <CBTEnableImportBuildPackages Condition=" '$(CBTEnableImportBuildPackages)' == '' ">true</CBTEnableImportBuildPackages>
     <CBTNuGetIntermediateOutputPath Condition=" '$(CBTNuGetIntermediateOutputPath)' == '' And '$(IntermediateOutputPath)' != '' ">$(IntermediateOutputPath)</CBTNuGetIntermediateOutputPath>
     <CBTNuGetIntermediateOutputPath Condition=" '$(CBTNuGetIntermediateOutputPath)' == '' And '$(IntermediateOutputPath)' == '' ">$(CBTIntermediateOutputPath)\$(MSBuildProjectDirectory.ToLower().Length.ToString())</CBTNuGetIntermediateOutputPath>
+    <CBTNuGetIntermediateOutputPath Condition=" '$(TargetFramework)' != '' ">$(CBTNuGetIntermediateOutputPath)\$(TargetFramework)</CBTNuGetIntermediateOutputPath>
     <CBTNuGetAssetsFlagFile Condition=" '$(CBTNuGetAssetsFlagFile)' == '' ">$(CBTNuGetIntermediateOutputPath)\$(MSBuildProjectFile).flag</CBTNuGetAssetsFlagFile>
   </PropertyGroup>
 


### PR DESCRIPTION

multi framework projects would hit this exception preventing them from generating the props.  I don't know enough about multi-framework builds to know what the right fix is but perhaps you will have an idea.  

I will play with it more like maybe have things only run if TargetFramework is defined or such so we don't need to change this behavior.  

But this is the first iteration to let you know what else was needed to get property generation to work.