### PR TITLE
Move the OutDir redirection logic to Before.Microsoft.Common.targets

### DIFF
--- a/src/CBT.UnifiedOutputDir/build/Before.Microsoft.Common.targets
+++ b/src/CBT.UnifiedOutputDir/build/Before.Microsoft.Common.targets
@@ -8,7 +8,7 @@
 
 
     <CBTRelativeOutputPathAppend Condition=" '$(CBTRelativeOutputPathAppend)' == '' and '$(CBTUnifiedOutputDirUseAssemblyName)' == 'true' ">$(AssemblyName)</CBTRelativeOutputPathAppend>
-    <CBTRelativeOutputPathAppend Condition=" '$(CBTRelativeOutputPathAppend)' == '' and '$(CBTUnifiedOutputDirUseAssemblyName)' == 'true' ">$(TargetName)</CBTRelativeOutputPathAppend>
+    <CBTRelativeOutputPathAppend Condition=" '$(CBTRelativeOutputPathAppend)' == '' and '$(CBTUnifiedOutputDirUseTargetName)' == 'true' ">$(TargetName)</CBTRelativeOutputPathAppend>
     <CBTRelativeOutputPathAppend Condition=" '$(CBTRelativeOutputPathAppend)' == '' ">$(MSBuildProjectName)</CBTRelativeOutputPathAppend>
     <CBTRelativeOutputPath Condition="'$(CBTSelfContainedBuildOutput)' == 'true'">$([System.IO.Path]::Combine($(CBTRelativeOutputPath), $(CBTRelativeOutputPathAppend)))</CBTRelativeOutputPath>
 

--- a/src/CBT.UnifiedOutputDir/build/Before.Microsoft.Common.targets
+++ b/src/CBT.UnifiedOutputDir/build/Before.Microsoft.Common.targets
@@ -6,8 +6,10 @@
     <CBTOutputRootDir Condition=" '$(CBTOutputRootDir)' == '' ">$(EnlistmentRoot)\bin\$(CBTOutputPathPlatformPart)\$(Configuration)</CBTOutputRootDir>
     <CBTOutputRootDir>$(CBTOutputRootDir.TrimEnd({'\\'}))</CBTOutputRootDir>
 
-    <CBTRelativeOutputPathAppend Condition="'$(CBTRelativeOutputPathAppend)' == '' and '$(CBTUnifiedOutputDirUseAssemblyName)' == 'true' ">$(AssemblyName)</CBTRelativeOutputPathAppend>
-    <CBTRelativeOutputPathAppend Condition="'$(CBTRelativeOutputPathAppend)' == ''">$(MSBuildProjectName)</CBTRelativeOutputPathAppend>
+
+    <CBTRelativeOutputPathAppend Condition=" '$(CBTRelativeOutputPathAppend)' == '' and '$(CBTUnifiedOutputDirUseAssemblyName)' == 'true' ">$(AssemblyName)</CBTRelativeOutputPathAppend>
+    <CBTRelativeOutputPathAppend Condition=" '$(CBTRelativeOutputPathAppend)' == '' and '$(CBTUnifiedOutputDirUseAssemblyName)' == 'true' ">$(TargetName)</CBTRelativeOutputPathAppend>
+    <CBTRelativeOutputPathAppend Condition=" '$(CBTRelativeOutputPathAppend)' == '' ">$(MSBuildProjectName)</CBTRelativeOutputPathAppend>
     <CBTRelativeOutputPath Condition="'$(CBTSelfContainedBuildOutput)' == 'true'">$([System.IO.Path]::Combine($(CBTRelativeOutputPath), $(CBTRelativeOutputPathAppend)))</CBTRelativeOutputPath>
 
     <!-- These variables are the ones that the standard MSBuild targets recognize.  We override them here.  -->

--- a/src/CBT.UnifiedOutputDir/build/Before.Microsoft.Common.targets
+++ b/src/CBT.UnifiedOutputDir/build/Before.Microsoft.Common.targets
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <CBTOutputRootDir Condition=" '$(CBTOverrideBaseOutputPath)' != '' ">$(CBTOverrideBaseOutputPath)</CBTOutputRootDir>
+    <CBTOutputPathPlatformPart Condition="'$(CBTOutputPathPlatformPart)' == ''">$(Platform)</CBTOutputPathPlatformPart>
+    <CBTOutputRootDir Condition=" '$(CBTOutputRootDir)' == '' ">$(EnlistmentRoot)\bin\$(CBTOutputPathPlatformPart)\$(Configuration)</CBTOutputRootDir>
+    <CBTOutputRootDir>$(CBTOutputRootDir.TrimEnd({'\\'}))</CBTOutputRootDir>
+
+    <CBTRelativeOutputPathAppend Condition="'$(CBTRelativeOutputPathAppend)' == '' and '$(CBTUnifiedOutputDirUseAssemblyName)' == 'true' ">$(AssemblyName)</CBTRelativeOutputPathAppend>
+    <CBTRelativeOutputPathAppend Condition="'$(CBTRelativeOutputPathAppend)' == ''">$(MSBuildProjectName)</CBTRelativeOutputPathAppend>
+    <CBTRelativeOutputPath Condition="'$(CBTSelfContainedBuildOutput)' == 'true'">$([System.IO.Path]::Combine($(CBTRelativeOutputPath), $(CBTRelativeOutputPathAppend)))</CBTRelativeOutputPath>
+
+    <!-- These variables are the ones that the standard MSBuild targets recognize.  We override them here.  -->
+    <OutDir Condition=" '$(OutDir)' =='' ">$([System.IO.Path]::Combine($(CBTOutputRootDir), $(CBTRelativeOutputPath)))</OutDir>
+
+    <!-- OutDir requires a trailing slash to prevent MSB8004 warning -->
+    <OutDir Condition="!HasTrailingSlash('$(OutDir)')">$(OutDir)\</OutDir>
+    <!-- This ensures OutputPath always matches OutDir, especially when TFS overrides OutDir. -->
+    <OutputPath>$(OutDir)</OutputPath>
+  </PropertyGroup>
+</Project>

--- a/src/CBT.UnifiedOutputDir/build/CBT.UnifiedOutputDir.props
+++ b/src/CBT.UnifiedOutputDir/build/CBT.UnifiedOutputDir.props
@@ -27,24 +27,10 @@
     <!-- In the projectJson package restore scenario you can not redefine the location of the json file.  If the ProjectAssetsFile is set then it will be assumed to be a PackageReference project.  -->
     <ProjectAssetsFile Condition="!Exists('$(MSBuildProjectDirectory)\project.json') And !Exists('$(MSBuildProjectDirectory)\package.config')" >$(MSBuildProjectExtensionsPath)project.assets.json</ProjectAssetsFile>
 
-    <CBTOutputRootDir Condition=" '$(CBTOverrideBaseOutputPath)' != '' ">$(CBTOverrideBaseOutputPath)</CBTOutputRootDir>
-    <CBTOutputPathPlatformPart Condition="'$(CBTOutputPathPlatformPart)' == ''">$(Platform)</CBTOutputPathPlatformPart>
-    <CBTOutputRootDir Condition=" '$(CBTOutputRootDir)' == '' ">$(EnlistmentRoot)\bin\$(CBTOutputPathPlatformPart)\$(Configuration)</CBTOutputRootDir>
-    <CBTOutputRootDir>$(CBTOutputRootDir.TrimEnd({'\\'}))</CBTOutputRootDir>
-
-    <CBTRelativeOutputPathAppend Condition="'$(CBTRelativeOutputPathAppend)' == ''">$(MSBuildProjectName)</CBTRelativeOutputPathAppend>
-    <CBTRelativeOutputPath Condition="'$(CBTSelfContainedBuildOutput)' == 'true'">$([System.IO.Path]::Combine($(CBTRelativeOutputPath), $(CBTRelativeOutputPathAppend)))</CBTRelativeOutputPath>
-
-    <!-- These variables are the ones that the standard MSBuild targets recognize.  We override them here.  -->
-    <OutDir Condition=" '$(OutDir)' =='' ">$([System.IO.Path]::Combine($(CBTOutputRootDir), $(CBTRelativeOutputPath)))</OutDir>
-
-    <!-- OutDir requires a trailing slash to prevent MSB8004 warning -->
-    <OutDir Condition="!HasTrailingSlash('$(OutDir)')">$(OutDir)\</OutDir>
-    <!-- This ensures OutputPath always matches OutDir, especially when TFS overrides OutDir. -->
-    <OutputPath>$(OutDir)</OutputPath>
-
     <!-- must redefine nuget module restore assetsfile location if redefing baseintermediateoutputpath to avoid collision. -->
     <RestoreOutputPath>$(IntermediateOutputPath)</RestoreOutputPath>
+
+    <CBTUnifiedOutputDirUseAssemblyName Condition=" '$(CBTUnifiedOutputDirUseAssemblyName)' == '' ">false</CBTUnifiedOutputDirUseAssemblyName>
   </PropertyGroup>
 
   <Import Project="$(CBTModuleExtensionsPath)\After.$(MSBuildThisFile)" Condition=" '$(CBTModuleExtensionsPath)' != '' And Exists('$(CBTModuleExtensionsPath)\After.$(MSBuildThisFile)') " />

--- a/src/CBT.UnifiedOutputDir/version.json
+++ b/src/CBT.UnifiedOutputDir/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0",
+  "version": "2.1",
   "buildNumberOffset": 0,
   "publicReleaseRefSpec": [
     "^refs/tags/CBT\\.UnifiedOutputDir.*"


### PR DESCRIPTION
This allows the user to override settings based on what's in the project file. Speficially, it lets us use the AssemblyName.

Add a new flag: CBTUnifiedOutputDirUseAssemblyName. When set to true, uses AssemblyName as the CBTRelativeOutputPathAppend. This is specified as a boolean to allows the user to set CBTUnifiedOutputDirUseAssemblyName to true in the directory.build.props before the AssemblyName is known.