### PR TITLE
Give option to not copy referenced output

### DIFF
--- a/src/CBT.NoTarget/build/NoTarget.targets
+++ b/src/CBT.NoTarget/build/NoTarget.targets
@@ -7,6 +7,13 @@
 
   <Import Project="$(CustomBeforeNoTargets)" Condition="'$(CustomBeforeNoTargets)' != '' and Exists('$(CustomBeforeNoTargets)')" />
 
+  <ItemDefinitionGroup Condition="'$(NoTargetsCopyReferenceOutput)' == 'true'" >
+    <ProjectReference>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <Private>false</Private>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+
   <Import Project="$(LanguageTargets)" Condition="Exists('$(LanguageTargets)')" />
   <Import Project="ClearItemsMSBuild15.targets" Condition = " '$(MSBuildToolsVersion)' != '4.0' And '$(MSBuildToolsVersion)' != '12.0' And '$(MSBuildToolsVersion)' != '14.0' " />
   <Import Project="ClearItemsMSBuildPrior15.targets" Condition = " '$(MSBuildToolsVersion)' == '4.0' Or '$(MSBuildToolsVersion)' == '12.0' Or '$(MSBuildToolsVersion)' == '14.0' " />

--- a/src/CBT.NoTarget/build/NoTarget.targets
+++ b/src/CBT.NoTarget/build/NoTarget.targets
@@ -7,7 +7,7 @@
 
   <Import Project="$(CustomBeforeNoTargets)" Condition="'$(CustomBeforeNoTargets)' != '' and Exists('$(CustomBeforeNoTargets)')" />
 
-  <ItemDefinitionGroup Condition="'$(NoTargetsCopyReferenceOutput)' == 'true'" >
+  <ItemDefinitionGroup Condition="'$(NoTargetsReferenceOutputAssembly)' == 'false'" >
     <ProjectReference>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <Private>false</Private>


### PR DESCRIPTION
NoTarget projects with ProjectReferences currently copy those referenced projects' output to their output folder. We'd like a flag to disable this.