### PR TITLE
Stop setting CBTEnablePackageRestore and rely on ExcludeRestorePackag…

### DIFF
--- a/src/CBT.NuGet/Tasks/NuGetRestore.cs
+++ b/src/CBT.NuGet/Tasks/NuGetRestore.cs
@@ -99,7 +99,6 @@ namespace CBT.NuGet.Tasks
             // CBTModulesRestored must be set so on it's evaluation it knows to import the generated module imports so it evaluates the proper full closure of the project.
             EnvironmentVariables = new[]
             {
-                "CBTEnablePackageRestore=false",
                 "CBTModulesRestored=true"
             };
 

--- a/src/CBT.NuGet/build/After.Microsoft.Common.targets
+++ b/src/CBT.NuGet/build/After.Microsoft.Common.targets
@@ -5,12 +5,12 @@
     <PrepareForBuildDependsOn Condition=" '$(CBTEnableNuGetPackageRestoreOptimization)' != 'false' ">_CheckForCBTNuGetPackagesRestoredMarker;$(PrepareForBuildDependsOn)</PrepareForBuildDependsOn>
     <RestoreDependsOn>$(RestoreDependsOn);RestoreNuGetPackages</RestoreDependsOn>
     <RestoreDependsOn Condition=" '$(CBTNuGetGeneratePackageProperties)' != 'false' ">$(RestoreDependsOn);GenerateNuGetProperties</RestoreDependsOn>
-	<CBTDesignTimeBuildDependsOn>$(CBTDesignTimeBuildDependsOn);GenerateNuGetAssetFlagFileInsideVisualStudio</CBTDesignTimeBuildDependsOn>
+    <CBTDesignTimeBuildDependsOn>$(CBTDesignTimeBuildDependsOn);GenerateNuGetAssetFlagFileInsideVisualStudio</CBTDesignTimeBuildDependsOn>
   </PropertyGroup>
 
   <Import Project="$(NuGetTargets)" Condition=" '$(NuGetTargets)' != '' And !Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.targets\ImportAfter\Microsoft.NuGet.ImportAfter.targets') " />
 
-  <Import Project="$(CBTBuildPackageTargetsFile)" Condition=" '$(CBTEnableImportBuildPackages)' != 'false' "/>
+  <Import Project="$(CBTBuildPackageTargetsFile)" Condition=" '$(CBTEnableImportBuildPackages)' != 'false' And Exists('$(CBTBuildPackageTargetsFile)') "/>
 
   <Target Name="GenerateNuGetAssetFlagFileInsideVisualStudio"
     Condition=" '$(BuildingInsideVisualStudio)' == 'true' "

--- a/src/CBT.NuGet/build/CBT.NuGet.props
+++ b/src/CBT.NuGet/build/CBT.NuGet.props
@@ -8,16 +8,6 @@
   <Import Project="$(CBTModuleExtensionsPath)\Before.$(MSBuildThisFile)" Condition=" '$(CBTModuleExtensionsPath)' != '' And Exists('$(CBTModuleExtensionsPath)\Before.$(MSBuildThisFile)') " />
 
   <PropertyGroup>
-    <!--
-        Disable package restore if a user ran NuGet.exe restore project.proj
-
-        NuGet.exe will write out an embedded NuGet.targets which calls an <MSBuild /> task against the original project with $(ExcludeRestorePackageImports) set to 'true'.  In this case, disable the restoring of packages as part of property evaluation.
-    -->
-    <CBTEnablePackageRestore Condition=" '$(CBTEnablePackageRestore)' == '' And ('$(ExcludeRestorePackageImports)' == 'true' Or '$(IsTraversal)' == 'true') ">false</CBTEnablePackageRestore>
-    <CBTEnablePackageRestore Condition=" '$(CBTEnablePackageRestore)' == '' ">true</CBTEnablePackageRestore>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <CBTNuGetTasksAssemblyPath Condition=" '$(CBTNuGetTasksAssemblyPath)' == '' ">$(MSBuildThisFileDirectory)net45\CBT.NuGet.dll</CBTNuGetTasksAssemblyPath>
     <CBTNuGetTasksSymbolsPath Condition=" '$(CBTNuGetTasksSymbolsPath)' == '' ">$(MSBuildThisFileDirectory)net45\CBT.NuGet.pdb</CBTNuGetTasksSymbolsPath>
     <CBTNuGetTasksAssemblyName Condition=" Exists($(CBTNuGetTasksAssemblyPath)) And Exists($(CBTNuGetTasksSymbolsPath)) And '$(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType(`System.AppDomain`).GetProperty(`CurrentDomain`).GetValue(null).GetData(`CBT_NUGET_ASSEMBLY`))' == '' ">$(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType('System.AppDomain').GetProperty('CurrentDomain').GetValue(null).SetData('CBT_NUGET_ASSEMBLY_PATH', $(CBTNuGetTasksAssemblyPath)))$(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType(`System.AppDomain`).GetProperty(`CurrentDomain`).GetValue(null).SetData(`CBT_NUGET_ASSEMBLY`, $(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType(`System.AppDomain`).GetProperty(`CurrentDomain`).GetValue(null).CreateInstanceFromAndUnwrap($(CBTNuGetTasksAssemblyPath), `CBT.NuGet.Tasks.NuGetRestore`).GetType().Assembly)))</CBTNuGetTasksAssemblyName>
@@ -54,7 +44,7 @@
 
   <PropertyGroup>
     <!-- Generating nuget package properties does not work for multi-framework projects.  The project.assets.json does not get created soon enough and the .flag file is which causes it to through a file doesn't exist exception.
-	This is due to their outer/inner build pattern. Instead of trying to "fix" this we have decided to deprecate this feature to prevent more people from taking a dependency on property generation.
+    This is due to their outer/inner build pattern. Instead of trying to "fix" this we have decided to deprecate this feature to prevent more people from taking a dependency on property generation.
     This is why we are deprecating it for all sdk projects and not just for the sdkproject package reference scenario.	-->
     <CBTNuGetGeneratePackageProperties Condition=" '$(CBTNuGetGeneratePackageProperties)' == '' And '$(UsingMicrosoftNETSdk)' == 'true' ">false</CBTNuGetGeneratePackageProperties>
     <CBTNuGetGeneratePackageProperties Condition=" '$(CBTNuGetGeneratePackageProperties)' == '' ">true</CBTNuGetGeneratePackageProperties>
@@ -70,7 +60,7 @@
     <NuGetMSBuildPath Condition=" '$(NuGetMSBuildPath)' == '' ">$(MSBuildBinPath)</NuGetMSBuildPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(CBTEnablePackageRestore)' == 'true' And '$(BuildingInsideVisualStudio)' != 'true' And '$(NuGet_ProjectReferenceToResolve)' == '' And '$(IsRestoreOnly)' != 'true' ">
+  <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' And '$(CBTEnablePackageRestore)' != 'false' And '$(BuildingInsideVisualStudio)' != 'true' And '$(NuGet_ProjectReferenceToResolve)' == '' And '$(IsRestoreOnly)' != 'true' ">
     <!-- Restore packages if not running under Visual Studio and not running as part of NuGet's restore -->
     <CBTNuGetPackagesRestored Condition=" '$(CBTNuGetPackagesRestored)' == '' And '$(CBTNuGetTasksAssemblyName)' != '' ">$(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType('System.AppDomain').GetProperty('CurrentDomain').GetValue(null).GetData('CBT_NUGET_ASSEMBLY').CreateInstance('CBT.NuGet.Tasks.NuGetRestore').Execute($(CBTNuGetRestoreFile), '$(NuGetMsBuildVersion)', $(CBTNuGetRestoreRequireConsent), $(CBTNuGetDisableParallelProcessing), $(NuGetFallbackSource.Split(';')), $(CBTNuGetNoCache), $(NuGetPackageSaveMode), $(NuGetSource.Split(';')), $(NuGetConfigFile), $(CBTNuGetNonInteractive), $(NuGetVerbosity), $(CBTNuGetTimeout), $(CBTNuGetPath), $([MSBuild]::ValueOrDefault('$(CBTEnableNuGetPackageRestoreOptimization)', 'true')), $(CBTNuGetPackagesRestoredMarker), $(CBTNuGetAllProjects.Split(';')), '$(NuGetMSBuildPath)', '$(CBTNuGetRestoreAdditionalArguments)'))</CBTNuGetPackagesRestored>
   </PropertyGroup>
@@ -84,7 +74,7 @@
     <CBTBuildPackageTargetsFile Condition=" '$(CBTBuildPackageTargetsFile)' == '' ">$(CBTModulePath)\NuGetBuildPackages.targets</CBTBuildPackageTargetsFile>
     <CBTBuildPackageImportInputs Condition=" '$(CBTBuildPackageImportInputs)' == '' ">$(MSBuildThisFileFullPath);$(CBTNuGetTasksAssemblyPath);$(CBTModulePackageConfigPath)</CBTBuildPackageImportInputs>
 
-    <CBTGlobalBuildPackagesCreated Condition=" '$(CBTGlobalBuildPackagesCreated)' != 'true' And '$(CBTNuGetTasksAssemblyName)' != '' ">$(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType('System.AppDomain').GetProperty('CurrentDomain').GetValue(null).GetData('CBT_NUGET_ASSEMBLY').CreateInstance('CBT.NuGet.Tasks.ImportBuildPackages').Execute('$(CBTModulePackageConfigPath)', '$(CBTBuildPackagePropsFile)', '$(CBTBuildPackageTargetsFile)', $(CBTBuildPackageImportInputs.Split(';')), $(CBTAllModulePaths.Split(';'))))</CBTGlobalBuildPackagesCreated>
+    <CBTGlobalBuildPackagesCreated Condition=" '$(ExcludeRestorePackageImports)' != 'true' And '$(CBTGlobalBuildPackagesCreated)' != 'true' And '$(CBTNuGetTasksAssemblyName)' != '' ">$(CBTNuGetTasksAssemblyPath.GetType().Assembly.GetType('System.AppDomain').GetProperty('CurrentDomain').GetValue(null).GetData('CBT_NUGET_ASSEMBLY').CreateInstance('CBT.NuGet.Tasks.ImportBuildPackages').Execute('$(CBTModulePackageConfigPath)', '$(CBTBuildPackagePropsFile)', '$(CBTBuildPackageTargetsFile)', $(CBTBuildPackageImportInputs.Split(';')), $(CBTAllModulePaths.Split(';'))))</CBTGlobalBuildPackagesCreated>
   </PropertyGroup>
 
   <ItemGroup>
@@ -124,7 +114,7 @@
   <!--
     Import build packages that were specified in the modules package config
   -->
-  <Import Project="$(CBTBuildPackagePropsFile)" Condition=" '$(CBTEnableImportBuildPackages)' != 'false' "/>
+  <Import Project="$(CBTBuildPackagePropsFile)" Condition=" '$(CBTEnableImportBuildPackages)' != 'false' And Exists('$(CBTBuildPackagePropsFile)') "/>
 
 
   <!-- If the NuGet restore targets are not in the import graph then rely on CBT already having restored the NuGet packages. If the restore targets are imported then this target will be overridden. -->
@@ -148,7 +138,7 @@
   <UsingTask AssemblyFile="$(CBTNuGetTasksAssemblyPath)" TaskName="CBT.NuGet.Tasks.GenerateNuGetProperties" />
 
   <Target Name="RestoreNuGetPackages"
-    Condition=" '$(CBTEnablePackageRestore)' == 'true' And '$(CBTNuGetPackagesRestored)' != 'true' And '$(BuildingInsideVisualStudio)' != 'true' "
+    Condition=" '$(CBTEnablePackageRestore)' != 'false' And '$(CBTNuGetPackagesRestored)' != 'true' And '$(BuildingInsideVisualStudio)' != 'true' "
     DependsOnTargets="_CheckForCBTNuGetPackagesRestoredMarker;$(RestoreNuGetPackagesDependsOn)"
     Inputs="$(CBTNuGetAllProjects);$(CBTNuGetRestoreFile)"
     Outputs="$(CBTNuGetPackagesRestoredMarker)">
@@ -186,7 +176,7 @@
 
   </Target>
 
- <!-- _GenerateRestoreProjectSpec is a from the NuGet.targets new to NuGet 4.x. This target must be in the props chaining in by the cbt\obj\modules\build.props and not in the after.microsoft.common.targets extension as the Microsoft common targets are not pulled in during the NuGet evaluation of the project. -->
+  <!-- _GenerateRestoreProjectSpec is a from the NuGet.targets new to NuGet 4.x. This target must be in the props chaining in by the cbt\obj\modules\build.props and not in the after.microsoft.common.targets extension as the Microsoft common targets are not pulled in during the NuGet evaluation of the project. -->
   <Target Name="GenerateNuGetAssetFlagFile" AfterTargets="_GenerateRestoreProjectSpec"  >
     <ItemGroup>
       <RestoreAssetsFlagData Remove="@(RestoreAssetsFlagData)"/>


### PR DESCRIPTION
…eImports instead

This makes it explicit that the evaluation is happening because of NuGet so skip things.