### PR TITLE
Minor improvements to GlobalRestoer

### DIFF
--- a/src/CBT.NuGet.GlobalRestore/build/After.Microsoft.Common.targets
+++ b/src/CBT.NuGet.GlobalRestore/build/After.Microsoft.Common.targets
@@ -7,7 +7,7 @@
   <UsingTask AssemblyFile="$(CBTNuGetTasksAssemblyPath)" TaskName="CBT.NuGet.Tasks.GenerateNuGetProperties" />
 
   <Target Name="RestoreGlobalNuGetPackages"
-    Condition=" '$(CBTNuGetGlobalPackagesRestored)' != 'true' "
+    Condition=" '$(CBTNuGetGlobalPackagesRestored)' != 'true' And '$(ExcludeRestorePackageImports)' != 'true' "
     Inputs="$(CBTNuGetAllProjects);$(CBTNuGetGlobalPackagesRestoreFile)"
     Outputs="$(CBTNuGetGlobalPackagesRestoredMarker)">
 

--- a/src/CBT.NuGet.GlobalRestore/build/After.Traversal.targets
+++ b/src/CBT.NuGet.GlobalRestore/build/After.Traversal.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <TraversalGlobalProperties>$(TraversalGlobalProperties);CBTNuGetGlobalPackagesRestored=$(CBTNuGetGlobalPackagesRestored);CBTNuGetGlobalPackagePropertiesCreated=$(CBTNuGetGlobalPackagePropertiesCreated)</TraversalGlobalProperties>
+    <TraversalGlobalProperties>$(TraversalGlobalProperties);CBTNuGetGlobalPackagesRestored=$(CBTNuGetGlobalPackagesRestored);CBTNuGetGlobalPackagePropertiesCreated=$(CBTNuGetGlobalPackagePropertiesCreated);CBTGlobalBuildPackagesCreated=$(CBTGlobalBuildPackagesCreated)</TraversalGlobalProperties>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Don't run RestoreGlobalNuGetPackages under NuGet's restore
Set CBTGlobalBuildPackagesCreated during traversal restore