### PR TITLE
Order packages in packages.config the same was as CoreXT

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   
+  <PropertyGroup>
+    <DebugType Condition="'$(Configuration)' == 'Debug'">Full</DebugType>
+  </PropertyGroup>
+  
   <Sdk Name="Microsoft.Build.CentralPackageVersions" />
 
   <ItemGroup Condition=" '$(IncludeBuildOutput)' == 'false' ">

--- a/src/CBT.NuGet.UnitTests/NuGetPathPropertiesTests.cs
+++ b/src/CBT.NuGet.UnitTests/NuGetPathPropertiesTests.cs
@@ -16,9 +16,12 @@ namespace CBT.NuGet.UnitTests
     public class NuGetPathPropertiesTests : TestBase
     {
         private readonly string _packageReferenceRestoreFlagContents = @"{""RestoreOutputAbsolutePath"": ""#RestoreOutputPath#"",""PackageImportOrder"": [{""Id"": ""Newtonsoft.Json"",""Version"": ""6.0.3""}],""RestoreProjectStyle"": ""PackageReference"",""ProjectJsonPath"": """"}";
-        private readonly string _packageConfigRestoreFlagContents = @"{""RestoreOutputAbsolutePath"": ""d:\\git\\CBT.Examples\\obj\\AnyCPU\\Debug\\ClassLibrary.csproj\\B34D2B84\\"",""PackageImportOrder"": [{""Id"": ""Newtonsoft.Json"",""Version"": ""6.0.1""}],""RestoreProjectStyle"": ""Unknown"",""ProjectJsonPath"": """"}";
+        private readonly string _packageConfigRestoreFlagContents = @"{""RestoreOutputAbsolutePath"": ""d:\\git\\CBT.Examples\\obj\\AnyCPU\\Debug\\ClassLibrary.csproj\\B34D2B84\\"",""PackageImportOrder"": [],""RestoreProjectStyle"": ""Unknown"",""ProjectJsonPath"": """"}";
         private readonly string _packageProjectJsonRestoreFlagContents = @"{""RestoreOutputAbsolutePath"": ""d:\\git\\CBT.Examples\\obj\\AnyCPU\\Debug\\ClassLibrary.csproj\\B34D2B84\\"",""PackageImportOrder"": [{""Id"": ""Newtonsoft.Json"",""Version"": ""6.0.1""}],""RestoreProjectStyle"": ""ProjectJson"",""ProjectJsonPath"": ""#JsonFile#""}";
-        private readonly string _packageConfigFileContents = @"<packages><package id=""Newtonsoft.Json"" version=""6.0.1""/></packages>";
+        private readonly string _packageConfigFileContents = @"<packages>
+    <package id=""Newtonsoft.Json"" version=""7.0.1""/>
+    <package id=""Newtonsoft.Json"" version=""6.0.1""/>
+</packages>";
         private readonly string _packageProjectJsonFileContents = @"{  ""dependencies"": {    ""NewtonSoft.Json"": ""6.0.3""  },  ""frameworks"": {    ""net45"": {}  },  ""runtimes"": {    ""win"": {}  }}";
 
         private readonly CBTTaskLogHelper _log = new CBTTaskLogHelper(new MockTask
@@ -172,15 +175,22 @@ namespace CBT.NuGet.UnitTests
 <Project ToolsVersion=""4.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <NuGetPath_Newtonsoft_Json>{TestRootPath}\packages\Newtonsoft.Json.6.0.1</NuGetPath_Newtonsoft_Json>
-    <NuGetVersion_Newtonsoft_Json>6.0.1</NuGetVersion_Newtonsoft_Json>
+    <NuGetPath_Newtonsoft_Json>{TestRootPath}\packages\Newtonsoft.Json.7.0.1</NuGetPath_Newtonsoft_Json>
+    <NuGetVersion_Newtonsoft_Json>7.0.1</NuGetVersion_Newtonsoft_Json>
   </PropertyGroup>
   <ItemGroup>
     <CBTNuGetPackageDir Include=""{TestRootPath}\packages\Newtonsoft.Json.6.0.1"" />
+    <CBTNuGetPackageDir Include=""{TestRootPath}\packages\Newtonsoft.Json.7.0.1"" />
   </ItemGroup>
 </Project>";
 
-            string packagePath = CreatePackagesFolder(new List<Tuple<string, string>> { new Tuple<string, string>("Newtonsoft.Json", "6.0.3") }, @"\");
+            string packagePath = CreatePackagesFolder(
+                new List<Tuple<string, string>>
+                {
+                    new Tuple<string, string>("Newtonsoft.Json", "7.0.1"),
+                    new Tuple<string, string>("Newtonsoft.Json", "6.0.1"),
+                },
+                @"\");
 
             MockSettings settings = new MockSettings
             {

--- a/src/CBT.NuGet.UnitTests/NuGetPathPropertiesTests.cs
+++ b/src/CBT.NuGet.UnitTests/NuGetPathPropertiesTests.cs
@@ -50,7 +50,11 @@ namespace CBT.NuGet.UnitTests
 
             File.WriteAllText(packageConfigFile, _packageConfigFileContents);
 
-            string packagePath = CreatePackagesFolder( new List<Tuple<string, string>> { new Tuple<string, string>("Newtonsoft.Json", "6.0.1") });
+            string packagePath = CreatePackagesFolder(new List<Tuple<string, string>>
+            {
+                new Tuple<string, string>("Newtonsoft.Json", "6.0.1"),
+                new Tuple<string, string>("Newtonsoft.Json", "7.0.1")
+            });
 
             MockSettings settings = new MockSettings
             {
@@ -65,7 +69,6 @@ namespace CBT.NuGet.UnitTests
             bool result = new NuGetPackagesConfigParser(settings, _log).TryGetPackages(packageConfigFile, packageRestoreData, out IEnumerable<PackageIdentityWithPath> packages);
 
             result.ShouldBeTrue();
-            packages.Count().ShouldBe(1);
 
             packageConfigFile = Path.Combine(TestRootPath, "foo.proj");
 
@@ -76,9 +79,9 @@ namespace CBT.NuGet.UnitTests
             result.ShouldBeTrue();
 
             IList<PackageIdentityWithPath> packageIdentityWithPaths = packages as IList<PackageIdentityWithPath> ?? packages.ToList();
-            packageIdentityWithPaths.Count.ShouldBe(1);
-            packageIdentityWithPaths.First().Id.ShouldBe("Newtonsoft.Json");
-            packageIdentityWithPaths.First().Version.ToString().ShouldBe("6.0.1");
+            packageIdentityWithPaths.Count.ShouldBe(2);
+            packageIdentityWithPaths.Select(i => i.Id).ShouldBe(new [] { "Newtonsoft.Json", "Newtonsoft.Json" });
+            packageIdentityWithPaths.Select(i => i.Version.ToString()).ShouldBe(new[] { "6.0.1", "7.0.1" });
         }
 
         [Fact]

--- a/src/CBT.NuGet/Internal/NuGetPackagesConfigParser.cs
+++ b/src/CBT.NuGet/Internal/NuGetPackagesConfigParser.cs
@@ -76,21 +76,25 @@ namespace CBT.NuGet.Internal
 
             PackagesConfigReader packagesConfigReader = new PackagesConfigReader(document);
 
-            packages = packagesConfigReader.GetPackages(allowDuplicatePackageIds: true).Select(i =>
-            {
-                string installPath = packagePathResolver.GetInstallPath(i.PackageIdentity);
-
-                if (!String.IsNullOrWhiteSpace(installPath))
+            packages = packagesConfigReader.GetPackages(allowDuplicatePackageIds: true)
+                .OrderBy(i => i.PackageIdentity.Id)
+                .ThenBy(i => i.PackageIdentity.Version)
+                .Select(i =>
                 {
-                    installPath = Path.GetFullPath(installPath);
-                }
-                else
-                {
-                    Log.LogWarning($"The package '{i.PackageIdentity.Id}' was not found in the repository.");
-                }
+                    string installPath = packagePathResolver.GetInstallPath(i.PackageIdentity);
 
-                return new PackageIdentityWithPath(i.PackageIdentity, installPath);
-            }).Where(i => !String.IsNullOrWhiteSpace(i.FullPath));
+                    if (!String.IsNullOrWhiteSpace(installPath))
+                    {
+                        installPath = Path.GetFullPath(installPath);
+                    }
+                    else
+                    {
+                        Log.LogWarning($"The package '{i.PackageIdentity.Id}' was not found in the repository.");
+                    }
+
+                    return new PackageIdentityWithPath(i.PackageIdentity, installPath);
+                })
+                .Where(i => !String.IsNullOrWhiteSpace(i.FullPath));
 
             return true;
         }


### PR DESCRIPTION
If a user copy/pastes a list of packages from a corext.config, the properties are not generated the same.  CoreXT sorts the packages so that the highest version of the package wins.  We were respecting the order inside the packages.config but we don't really support multiple versions so the last declared package would win.  This now sorts the packages so that the last one is the highest version which mirrors the functionality in CoreXT