### PR TITLE
Use lowercase version of hash file name in NuGet.Deterministic

### DIFF
--- a/src/NuGet.Deterministic/GenerateLockedPackageReferencesFile.cs
+++ b/src/NuGet.Deterministic/GenerateLockedPackageReferencesFile.cs
@@ -190,7 +190,7 @@ namespace NuGet.Tasks.Deterministic
                 {VersionMetadataName, $"[{library.Version}]"},
                 {Sha512MetadataName, library.Sha512},
                 {PackagePathMetadataName, library.Path},
-                {HashfileMetadataName, library.Files.First(i => i.EndsWith("nupkg.sha512"))},
+                {HashfileMetadataName, library.Files.First(i => i.EndsWith("nupkg.sha512", StringComparison.OrdinalIgnoreCase)).ToLowerInvariant()},
             };
 
             if (libraryDependency != null)


### PR DESCRIPTION
If the casing differs from machine to machine on the nupkg.sha512 file, then the NuGetAssetsLock.props is regenerated every time.  The fix is to lowercase the path in NuGetAssetsLock.props

Fixes #280