### PR TITLE
Add loaded projects as inputs for traversal restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ publish/
 !CBT.NuGet.targets
 !Before.CBT.NuGet.props
 !After.CBT.NuGet.props
+launchSettings.json
 
 # Microsoft Azure Build Output
 csx/


### PR DESCRIPTION
Fixes an issue where restore doesn't happen again if a dirs.proj deeper in the tree changes.

Added the list of traversal projects to dirs.proj.projects and then pass along all of the projects as inputs to restore.