### PR TITLE
General perf improvements for CBT.NuGet

### DIFF
--- a/src/CBT.NuGet/Tasks/TraversalNuGetRestore.cs
+++ b/src/CBT.NuGet/Tasks/TraversalNuGetRestore.cs
@@ -162,7 +162,7 @@ namespace CBT.NuGet.Tasks
             {
                 writer.WriteLine("Microsoft Visual Studio Solution File, Format Version 12.00");
 
-                foreach (var project in projectCollection.LoadedProjects)
+                foreach (var project in projectCollection.LoadedProjects.Where(i => !String.Equals(i.GetPropertyValue("IsTraversal"), "true", StringComparison.OrdinalIgnoreCase)))
                 {
                     Uri toUri = new Uri(project.FullPath, UriKind.Absolute);
 

--- a/src/CBT.NuGet/build/After.Microsoft.Common.targets
+++ b/src/CBT.NuGet/build/After.Microsoft.Common.targets
@@ -13,7 +13,7 @@
   <Import Project="$(CBTBuildPackageTargetsFile)" Condition=" '$(CBTEnableImportBuildPackages)' != 'false' And Exists('$(CBTBuildPackageTargetsFile)') "/>
 
   <Target Name="GenerateNuGetAssetFlagFileInsideVisualStudio"
-    Condition=" '$(BuildingInsideVisualStudio)' == 'true' "
+    Condition=" '$(BuildingInsideVisualStudio)' == 'true' And '$(CBTNuGetGeneratePackageProperties)' == 'true'"
     Inputs="$(CBTNuGetRestoreFile)"
     Outputs="$(CBTNuGetAssetsFlagFile)">
 

--- a/src/CBT.NuGet/build/CBT.NuGet.props
+++ b/src/CBT.NuGet/build/CBT.NuGet.props
@@ -181,7 +181,7 @@
   </Target>
 
   <!-- _GenerateRestoreProjectSpec is a from the NuGet.targets new to NuGet 4.x. This target must be in the props chaining in by the cbt\obj\modules\build.props and not in the after.microsoft.common.targets extension as the Microsoft common targets are not pulled in during the NuGet evaluation of the project. -->
-  <Target Name="GenerateNuGetAssetFlagFile" AfterTargets="_GenerateRestoreProjectSpec"  >
+  <Target Name="GenerateNuGetAssetFlagFile" AfterTargets="_GenerateRestoreProjectSpec" Condition=" '$(CBTNuGetGeneratePackageProperties)' == 'true' ">
     <ItemGroup>
       <RestoreAssetsFlagData Remove="@(RestoreAssetsFlagData)"/>
       <RestoreAssetsFlagData Include="ProjectJsonPath">


### PR DESCRIPTION
* Don't write out the assets flag file if `CBTNuGetGeneratePackageProperties` is `false`.  The flag file is only used for property generation so there's no point in running the target if the data isn't used
* Exclude traversal projects from the generated SLN file in Traversal Restore.  NuGet restores packages for `dirs.proj` which adds unneeded overhead.