### PR TITLE
Don't generate restore file for traversal projects since they are filtered out of the SLN now

### DIFF
--- a/src/CBT.NuGet/Tasks/TraversalNuGetRestore.cs
+++ b/src/CBT.NuGet/Tasks/TraversalNuGetRestore.cs
@@ -81,7 +81,7 @@ namespace CBT.NuGet.Tasks
         {
             if (_enableOptimization)
             {
-                foreach (Project loadedProject in _projectCollection.LoadedProjects)
+                foreach (Project loadedProject in _projectCollection.LoadedProjects.Where(i => !String.Equals(i.GetPropertyValue("IsTraversal"), "true", StringComparison.OrdinalIgnoreCase)))
                 {
                     string restoreMarkerPath = loadedProject.GetPropertyValue("CBTNuGetPackagesRestoredMarker");
 


### PR DESCRIPTION
Fixes an issue where `dirs.proj` doesn't get restored and targets from packages aren't imported.